### PR TITLE
Drop 'mimir-' prefix from relation names

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -33,38 +33,40 @@ resources:
     description: OCI image for Grafana Agent
 
 requires:
-  # On the same mimir_worker interface, the coordinator will accept one relation to a worker per each Mimir component.
+  # On the same mimir_worker interface, the coordinator will accept one relation to a worker per
+  # each Mimir component.
   # The relation(s) determine the role(s) the worker will assume.
-  # Each Mimir worker can take on multiple roles; however, there can be no role replication among workers related to the
-  # same coordinator, which is why we force `limit: 1`.
-  mimir-compactor:
+  # Each Mimir worker can take on multiple roles; however, there can be no role replication among
+  # workers related to the same coordinator, which is why we force `limit: 1`.
+  # Note: relation names exactly match Mimir roles.
+  compactor:
     interface: mimir_worker
     limit: 1
-  mimir-distributor:
+  distributor:
     interface: mimir_worker
     limit: 1
-  mimir-ingester:
+  ingester:
     interface: mimir_worker
     limit: 1
-  mimir-querier:
+  querier:
     interface: mimir_worker
     limit: 1
-  mimir-query-frontend:
+  query-frontend:
     interface: mimir_worker
     limit: 1
-  mimir-store-gateway:
+  store-gateway:
     interface: mimir_worker
     limit: 1
-  mimir-alertmanager:
+  alertmanager:
     interface: mimir_worker
     limit: 1
-  mimir-ruler:
+  ruler:
     interface: mimir_worker
     limit: 1
-  mimir-overrides-exporter:
+  overrides-exporter:
     interface: mimir_worker
     limit: 1
-  mimir-query-scheduler:
+  query-scheduler:
     interface: mimir_worker
     limit: 1
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -35,7 +35,7 @@ class MimirCoordinatorK8SOperatorCharm(CharmBase):
         self.framework.observe(self.on.config_changed, self._on_config_changed)
 
         self.framework.observe(
-            self.on.mimir_ruler_relation_joined, self._on_ruler_joined  # pyright: ignore
+            self.on.ruler_relation_joined, self._on_ruler_joined  # pyright: ignore
         )
 
         # TODO: On any worker relation-joined/departed, need to updade grafana agent's scrape

--- a/src/mimir_coordinator.py
+++ b/src/mimir_coordinator.py
@@ -50,8 +50,7 @@ deployment to be considered robust according to the official recommendations/gui
 
 
 def _endpoint_to_role(endpoint: str) -> MimirRole:
-    stripped = endpoint[6:]
-    return MimirRole(stripped.replace("-", "_"))
+    return MimirRole(endpoint.replace("-", "_"))
 
 
 class MimirCoordinator:

--- a/tests/scenario/test_coherence.py
+++ b/tests/scenario/test_coherence.py
@@ -13,7 +13,7 @@ from scenario import Context, Relation, State
 
 
 def _to_endpoint_name(role: MimirRole):
-    return "mimir-" + role.value.replace("_", "-")
+    return role.value.replace("_", "-")
 
 
 ALL_MIMIR_RELATION_NAMES = list(map(_to_endpoint_name, MimirRole))


### PR DESCRIPTION
## Issue
Before this PR, charm code needed to add/remove the "mimir-" prefix when converting between relation names and role names.


## Solution
Have the mimir relation names match exactly Mimir roles.