### PR TITLE
Decouple workload, configuration management from charm.py

### DIFF
--- a/src/agent_config.py
+++ b/src/agent_config.py
@@ -1,1 +1,135 @@
 """Grafana agent config builder."""
+
+from typing import Any, Dict, List, Optional
+
+from charms.observability_libs.v0.juju_topology import JujuTopology
+
+
+class Config:
+    """A 'config builder' for grafana agent."""
+
+    def __init__(
+        self,
+        *,
+        topology: JujuTopology,
+        scrape_configs: Optional[list] = None,
+        remote_write: Optional[List[Dict[str, Any]]] = None,
+        loki_endpoints: Optional[List[dict]] = None,
+        positions_dir: str = "/run",
+        insecure_skip_verify: bool = False,
+        http_listen_port: int = 3500,
+        grpc_listen_port: int = 3600,
+    ):
+        self._topology = topology
+
+        scrape_configs = (scrape_configs or []).copy()
+        remote_write = (remote_write or []).copy()
+        loki_endpoints = (loki_endpoints or []).copy()
+
+        for endpoint in remote_write + loki_endpoints:
+            endpoint["tls_config"] = {"insecure_skip_verify": insecure_skip_verify}
+
+        self._config = {
+            "server": {"log_level": "info"},
+            "integrations": self._integrations_config(remote_write),
+            "metrics": {
+                "wal_directory": "/tmp/agent/data",  # should match metadata
+                "configs": [
+                    {
+                        "name": "agent_scraper",
+                        "scrape_configs": scrape_configs,
+                        "remote_write": remote_write,
+                    }
+                ],
+            },
+            "logs": {
+                "positions_directory": f"{positions_dir.rstrip('/')}/grafana-agent-positions",
+                "configs": [
+                    {
+                        "name": "push_api_server",
+                        "clients": loki_endpoints,
+                        "scrape_configs": [
+                            {
+                                "job_name": "loki",
+                                "loki_push_api": {
+                                    "server": {
+                                        "http_listen_port": http_listen_port,
+                                        "grpc_listen_port": grpc_listen_port,
+                                    },
+                                },
+                            }
+                        ],
+                    }
+                ],  # TODO: capture `_additional_log_configs` logic for the machine charm
+            },
+        }
+
+        # Seems like we cannot have an empty "configs" section. Delete it if no endpoints.
+        if not loki_endpoints:
+            self._config["logs"] = {}
+
+    def _instance_name(self) -> str:
+        parts = [
+            self._topology.model,
+            self._topology.model_uuid,
+            self._topology.application,
+            self._topology.unit,
+        ]
+        return "_".join(parts)  # TODO do we also need to `replace("/", "_")` ?
+
+    def _integrations_config(self, remote_write) -> dict:
+        """Return the integrations section of the config.
+
+        Returns:
+            The dict representing the config
+        """
+        # Align the "job" name with those of prometheus_scrape
+        job_name = "juju_{}_{}_{}_self-monitoring".format(
+            self._topology.model, self._topology.model_uuid, self._topology.application
+        )
+
+        conf = {
+            "agent": {
+                "enabled": True,
+                "relabel_configs": [
+                    {
+                        "target_label": "job",
+                        "regex": "(.*)",
+                        "replacement": job_name,
+                    },
+                    {  # Align the "instance" label with the rest of the Juju-collected metrics
+                        "target_label": "instance",
+                        "regex": "(.*)",
+                        "replacement": self._instance_name,
+                    },
+                    {  # To add a label, we create a relabelling that replaces a built-in
+                        "source_labels": ["__address__"],
+                        "target_label": "juju_charm",
+                        "replacement": self._topology.charm_name,
+                    },
+                    {  # To add a label, we create a relabelling that replaces a built-in
+                        "source_labels": ["__address__"],
+                        "target_label": "juju_model",
+                        "replacement": self._topology.model,
+                    },
+                    {
+                        "source_labels": ["__address__"],
+                        "target_label": "juju_model_uuid",
+                        "replacement": self._topology.model_uuid,
+                    },
+                    {
+                        "source_labels": ["__address__"],
+                        "target_label": "juju_application",
+                        "replacement": self._topology.application,
+                    },
+                    {
+                        "source_labels": ["__address__"],
+                        "target_label": "juju_unit",
+                        "replacement": self._topology.unit,
+                    },
+                ],
+            },
+            "prometheus_remote_write": remote_write,
+            # TODO capture `_additional_integrations` logic for the machine charm
+        }
+        return conf

--- a/src/agent_config.py
+++ b/src/agent_config.py
@@ -1,0 +1,1 @@
+"""Grafana agent config builder."""

--- a/src/agent_config.py
+++ b/src/agent_config.py
@@ -73,8 +73,12 @@ class Config:
         if not self.loki_endpoints:
             config["logs"] = {}
 
+        # TODO add a roundtrip check that the config is valid (dump then load), and set status
+        #  accordingly
+
         return config
 
+    @property
     def _instance_name(self) -> str:
         parts = [
             self._topology.model,

--- a/src/agent_workload.py
+++ b/src/agent_workload.py
@@ -1,4 +1,4 @@
-"""Workload manager for grafna agent."""
+"""Workload manager for grafana agent."""
 
 import logging
 import pathlib

--- a/src/agent_workload.py
+++ b/src/agent_workload.py
@@ -9,8 +9,8 @@ import yaml
 from ops.framework import Object
 from ops.model import ActiveStatus, StatusBase, UnknownStatus, WaitingStatus
 from ops.pebble import APIError, PathError
-from yaml.parser import ParserError
 from yaml.constructor import ConstructorError
+from yaml.parser import ParserError
 
 logger = logging.getLogger(__name__)
 

--- a/src/agent_workload.py
+++ b/src/agent_workload.py
@@ -10,6 +10,7 @@ from ops.framework import Object
 from ops.model import ActiveStatus, StatusBase, UnknownStatus, WaitingStatus
 from ops.pebble import APIError, PathError
 from yaml.parser import ParserError
+from yaml.constructor import ConstructorError
 
 logger = logging.getLogger(__name__)
 
@@ -162,8 +163,10 @@ class WorkloadManager(Object):
         assert config is not None
 
         try:
-            old_config = yaml.safe_load(self.read_file(self.CONFIG_PATH))
-        except (FileNotFoundError, PathError, ParserError):
+            old_config = self.read_file(self.CONFIG_PATH)
+            logger.info("Old config: %s", old_config)
+            old_config = yaml.safe_load(old_config)
+        except (FileNotFoundError, PathError, ParserError, ConstructorError):
             # The file does not yet exist?
             old_config = None
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -34,11 +34,10 @@ class MimirCoordinatorK8SOperatorCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
         self.grafana_agent_workload = WorkloadManager(
-            self, container_name="agent", config_getter=lambda: {}
-        )
-        self.framework.observe(
-            self.grafana_agent_workload.on.status_changed,  # pyright: ignore
-            self._update_unit_status,
+            self,
+            container_name="agent",
+            config_getter=lambda: {},  # TODO
+            status_changed_callback=self._update_unit_status,
         )
 
         self.framework.observe(self.on.config_changed, self._on_config_changed)

--- a/src/charm.py
+++ b/src/charm.py
@@ -81,7 +81,7 @@ class MimirCoordinatorK8SOperatorCharm(CharmBase):
                 insecure_skip_verify=True,
                 http_listen_port=3500,
                 grpc_listen_port=3600,
-            ).build,  # TODO figure out what to do about potential code ordering problem
+            ).build(),  # TODO figure out what to do about potential code ordering problem
             status_changed_callback=self._update_unit_status,
         )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -70,21 +70,18 @@ class MimirCoordinatorK8SOperatorCharm(CharmBase):
             self._on_loki_relation_changed,
         )
 
-        # TODO figure out what to do about potential code ordering problem
-        self.grafana_agent_config = Config(
-            topology=JujuTopology.from_charm(self),
-            scrape_configs=None,  # FIXME generate from memberlist
-            remote_write=self.remote_write_consumer.endpoints,
-            loki_endpoints=self.loki_consumer.loki_endpoints,
-            insecure_skip_verify=True,
-            http_listen_port=3500,
-            grpc_listen_port=3600,
-        )
-
         self.grafana_agent_workload = WorkloadManager(
             self,
             container_name="agent",
-            config_getter=lambda: {},  # TODO
+            config_getter=lambda: Config(
+                topology=JujuTopology.from_charm(self),
+                scrape_configs=None,  # FIXME generate from memberlist
+                remote_write=self.remote_write_consumer.endpoints,
+                loki_endpoints=self.loki_consumer.loki_endpoints,
+                insecure_skip_verify=True,
+                http_listen_port=3500,
+                grpc_listen_port=3600,
+            ).build,  # TODO figure out what to do about potential code ordering problem
             status_changed_callback=self._update_unit_status,
         )
 

--- a/src/workload.py
+++ b/src/workload.py
@@ -1,0 +1,145 @@
+from typing import Optional, Callable, Union
+import re
+import yaml
+import logging
+import pathlib
+from ops.pebble import PathError, APIError
+from dataclasses import dataclass
+from ops.model import BlockedStatus, WaitingStatus
+from yaml.parser import ParserError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Status:
+    """'Dumb struct' for helping with centralized status setting."""
+
+    # None = good; do not use ActiveStatus here.
+    update_config: Optional[Union[BlockedStatus, WaitingStatus]] = None
+
+
+class WorkloadManager:
+    CONFIG_PATH = "/etc/grafana-agent.yaml"
+
+    def __init__(self, charm, container_name: str, config_getter: Callable[[], ...]):
+        # Property to facilitate centralized status update
+        self.status = Status()
+
+        self._unit = charm.unit
+
+        self._service_name = self._container_name = container_name
+        self._container = charm.unit.get_container(container_name)
+
+        self._render_config = config_getter
+
+        # turn the container name to a valid Python identifier
+        snake_case_container_name = self._container_name.replace("-", "_")
+        charm.framework.observe(
+            getattr(charm.on, "{}_pebble_ready".format(snake_case_container_name)),
+            self._on_pebble_ready,
+        )
+
+    def _cli_args(self) -> str:
+        """Return the cli arguments to pass to agent.
+
+        Returns:
+            The arguments as a string
+        """
+        return f"-config.file={self.CONFIG_PATH}"
+
+    def _on_pebble_ready(self):
+        self.write_file(self.CONFIG_PATH, yaml.dump(self._render_config()))
+
+        pebble_layer = {
+            "summary": "agent layer",
+            "description": "pebble config layer for Grafana Agent",
+            "services": {
+                "agent": {
+                    "override": "replace",
+                    "summary": "agent",
+                    "command": f"/bin/agent {self._cli_args()}",
+                    "startup": "enabled",
+                },
+            },
+        }
+        self._container.add_layer(self._service_name, pebble_layer, combine=True)
+        self._container.autostart()
+
+        if version := self.version:
+            self._unit.set_workload_version(version)
+        else:
+            logger.debug(
+                "Cannot set workload version at this time: could not get grafana-agent version."
+            )
+
+        # self._update_status()
+
+    def is_ready(self):
+        return self._container.can_connect()
+
+    @property
+    def version(self) -> Optional[str]:
+        """Returns the version of the agent.
+
+        Returns:
+            A string equal to the agent version
+        """
+        if not self.is_ready:
+            return None
+
+        # Output looks like this:
+        # agent, version v0.26.1 (branch: HEAD, revision: 2b88be37)
+        version_output, _ = self._container.exec(["/bin/agent", "-version"]).wait_output()
+        result = re.search(r"v(\d*\.\d*\.\d*)", version_output)
+        return result.group(1) if result else None
+
+    def read_file(self, filepath: Union[str, pathlib.Path]):
+        """Read a file's contents.
+
+        Returns:
+            A string with the file's contents
+        """
+        return self._container.pull(filepath).read()
+
+    def write_file(self, path: Union[str, pathlib.Path], text: str) -> None:
+        """Write text to a file.
+
+        Args:
+            path: file path to write to
+            text: text to write to the file
+        """
+        self._container.push(path, text, make_dirs=True)
+
+    def restart(self) -> None:
+        """Restart grafana agent."""
+        self._container.restart(self._service_name)
+
+    def _update_config(self) -> None:
+        if not self.is_ready:
+            # Workload is not yet available so no need to update config
+            self.status.update_config = WaitingStatus("Workload is not yet available")
+            return
+
+        config = self._render_config()  # TODO: Must not be None
+        assert config is not None
+
+        try:
+            old_config = yaml.safe_load(self.read_file(self.CONFIG_PATH))
+        except (FileNotFoundError, PathError, ParserError):
+            # The file does not yet exist?
+            old_config = None
+
+        if config == old_config:
+            # Nothing changed, possibly new installation. Move on.
+            self.status.update_config = None
+            return
+
+        try:
+            self.write_file(self.CONFIG_PATH, yaml.dump(config))
+            self.restart()  # to pick up the new config
+        except APIError as e:
+            logger.warning(str(e))
+            self.status.update_config = WaitingStatus(str(e))
+
+        self.status.update_config = None

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,16 +4,24 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import unittest
+from unittest.mock import patch
 
 from charm import MimirCoordinatorK8SOperatorCharm
 from ops.model import ActiveStatus
 from ops.testing import Harness
+from workload import WorkloadManager
 
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
+        version_patcher = patch.object(WorkloadManager, "version", property(lambda *_: "1.2.3"))
+        self.version_patch = version_patcher.start()
+        self.addCleanup(version_patcher.stop)
+
         self.harness = Harness(MimirCoordinatorK8SOperatorCharm)
         self.addCleanup(self.harness.cleanup)
+        self.harness.set_leader(True)
+        self.harness.add_storage("data", attach=True)
         self.harness.begin_with_initial_hooks()
 
     def test_simple(self):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,6 +4,7 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import unittest
+import uuid
 from unittest.mock import patch
 
 from agent_workload import WorkloadManager
@@ -20,6 +21,7 @@ class TestCharm(unittest.TestCase):
 
         self.harness = Harness(MimirCoordinatorK8SOperatorCharm)
         self.addCleanup(self.harness.cleanup)
+        self.harness.set_model_info(name="testing", uuid=str(uuid.uuid4()))
         self.harness.set_leader(True)
         self.harness.add_storage("data", attach=True)
         self.harness.begin_with_initial_hooks()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,10 +6,10 @@
 import unittest
 from unittest.mock import patch
 
+from agent_workload import WorkloadManager
 from charm import MimirCoordinatorK8SOperatorCharm
 from ops.model import ActiveStatus
 from ops.testing import Harness
-from workload import WorkloadManager
 
 
 class TestCharm(unittest.TestCase):


### PR DESCRIPTION
In this PR a few parts of operating grafana agent have been decoupled from `charm.py`.
Something similar is expected to follow in a future PR for operating nginx.

- Split out "WorkloadManager" and "Config".
- Set up stage for the config to be lazily evaluated, in an attempt to avoid code ordering issues.
- New "compound status" handling approach:
  - Charm components report back via a callback
  - Each component, and then the charm, are responsible for calculating the "total" status for themselves

Apart from that, most of the code was copy-pasted from grafana agent (k8s operator).