### PR TITLE
fix nginx config when one or more roles are missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ extend-exclude = ["__pycache__", "*.egg_info"]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
 [tool.ruff.mccabe]
-max-complexity = 10
+max-complexity = 15
 
 [tool.pyright]
 include = ["src"]


### PR DESCRIPTION
Currently, when the coordinator is not related to any worker, the **nginx** workload fails to start. This happens because the load balancing section is missing from the configuration, as it's a result of iterating over all the workers.

This PR makes the re-routing `location` directives conditional on the roles being present, so that **nginx** can start even when the coordinator is initially deployed without workers.