### PR TITLE
fixed issue with data dir overlapping recovery storage dir

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,10 +13,6 @@ containers:
   nginx:
     resource: nginx-image
 
-storage:
-  data:
-    type: filesystem
-
 resources:
   nginx-image:
     type: oci-image

--- a/src/charm.py
+++ b/src/charm.py
@@ -146,9 +146,11 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
     def _on_collect_status(self, event: CollectStatusEvent):
         """Handle start event."""
         if not self.coordinator.is_coherent():
+            missing_roles = [role.value for role in self.coordinator.missing_roles()]
             event.add_status(
                 ops.BlockedStatus(
-                    "Incoherent deployment: you are lacking some required Mimir roles"
+                    f"Incoherent deployment: you are lacking some required Mimir roles "
+                    f"({missing_roles})"
                 )
             )
         s3_config_data = self._get_s3_storage_config()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -21,7 +21,7 @@ class TestMimirConfig(unittest.TestCase):
 
     def test_build_alertmanager_storage_config(self):
         alertmanager_storage_config = self.coordinator._build_alertmanager_storage_config()
-        expected_config = {"filesystem": {"dir": "/data/data-alertmanager-recovery"}}
+        expected_config = {"filesystem": {"dir": "/recovery-data/data-alertmanager"}}
         self.assertEqual(alertmanager_storage_config, expected_config)
 
     def test_build_compactor_config(self):

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,9 @@ commands =
               --skip {toxinidir}/.git \
               --skip {toxinidir}/.tox \
               --skip {toxinidir}/build \
+              --skip {toxinidir}/prime \  # bug in charmcraft 2.5.3 does not clean up build dirs
+              --skip {toxinidir}/stage \
+              --skip {toxinidir}/parts \
               --skip {toxinidir}/lib \
               --skip {toxinidir}/venv \
               --skip {toxinidir}/.mypy_cache \


### PR DESCRIPTION
- Fixes https://github.com/canonical/mimir-worker-k8s-operator/issues/24
- added missing roles to error status message when blocked

Tandem PR: https://github.com/canonical/mimir-worker-k8s-operator/pull/25

Testing instructions:

```
bundle: kubernetes                           
applications:                                
  coord:                                     
    charm: local:mimir-coordinator-k8s-0     
    scale: 1                                 
    constraints: arch=amd64                  
    storage:                                 
      data: kubernetes,1,1024M               
  worker:                                   
    charm: local:mimir-worker-k8s-0          
    scale: 1                                 
    options:                                 
      all: true                              
    constraints: arch=amd64                  
    storage:                                 
      data: kubernetes,1,1024M               
      recovery-data: kubernetes,1,1024M      
relations:                                   
- - coord:mimir-cluster                      
  - worker:mimir-cluster                    
```

And watch it go green.
