### PR TITLE
add replicas config for monolithic deployment

### DIFF
--- a/src/mimir_config.py
+++ b/src/mimir_config.py
@@ -25,6 +25,8 @@ class InvalidConfigurationError(Exception):
 class Memberlist(BaseModel):
     """Memberlist schema."""
 
+    cluster_label: str
+    cluster_label_verification_disabled: bool = False
     join_members: List[str]
 
 
@@ -61,6 +63,7 @@ class Ring(BaseModel):
     """Ring schema."""
 
     kvstore: Kvstore
+    replication_factor: int = 3
 
 
 class Distributor(BaseModel):

--- a/src/nginx.py
+++ b/src/nginx.py
@@ -219,7 +219,7 @@ class Nginx:
                         "args": ["$http_x_scope_orgid", "$ensured_x_scope_orgid"],
                         "block": [
                             {"directive": "default", "args": ["$http_x_scope_orgid"]},
-                            {"directive": "", "args": ["FIXMEnoAuthTenant?"]},  # FIXME
+                            {"directive": "", "args": ["anonymous"]},
                         ],
                     },
                     {"directive": "proxy_read_timeout", "args": ["300"]},

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -16,7 +16,10 @@ class TestMimirConfig(unittest.TestCase):
 
     def test_build_alertmanager_config(self):
         alertmanager_config = self.coordinator._build_alertmanager_config()
-        expected_config = {"data_dir": "/data/data-alertmanager"}
+        expected_config = {
+            "data_dir": "/data/data-alertmanager",
+            "sharding_ring": {"replication_factor": 1},
+        }
         self.assertEqual(alertmanager_config, expected_config)
 
     def test_build_alertmanager_storage_config(self):
@@ -105,7 +108,10 @@ class TestMimirConfig(unittest.TestCase):
     def test_build_memberlist_config(self):
         self.cluster_provider.gather_addresses.return_value = ["address1", "address2"]
         memberlist_config = self.coordinator._build_memberlist_config()
-        expected_config = {"join_members": ["address1", "address2"]}
+        expected_config = {"cluster_label": "something", "join_members": ["address1", "address2"]}
+        self.assertIn("cluster_label", expected_config)
+        memberlist_config.pop("cluster_label")
+        expected_config.pop("cluster_label")
         self.assertEqual(memberlist_config, expected_config)
 
     def test_build_tls_config(self):


### PR DESCRIPTION
When a role between **ingester**, **alertmanager**, and **store_gateway** has less than 3 worker units, we need to set the `replication_factor` for that role to one.  
If we have 3 or more units, we should stick to the default value of 3 for all of them.

This PR also sets the `cluster_label` parameter to a value extracted from the coordinator's topology.