### PR TITLE
add insecure to s3 config based on scheme

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 44
+LIBPATCH = 45
 
 PYDEPS = ["cosl"]
 
@@ -1537,12 +1537,11 @@ class MetricsEndpointProvider(Object):
             relation.data[self._charm.app]["scrape_metadata"] = json.dumps(self._scrape_metadata)
             relation.data[self._charm.app]["scrape_jobs"] = json.dumps(self._scrape_jobs)
 
-            if alert_rules_as_dict:
-                # Update relation data with the string representation of the rule file.
-                # Juju topology is already included in the "scrape_metadata" field above.
-                # The consumer side of the relation uses this information to name the rules file
-                # that is written to the filesystem.
-                relation.data[self._charm.app]["alert_rules"] = json.dumps(alert_rules_as_dict)
+            # Update relation data with the string representation of the rule file.
+            # Juju topology is already included in the "scrape_metadata" field above.
+            # The consumer side of the relation uses this information to name the rules file
+            # that is written to the filesystem.
+            relation.data[self._charm.app]["alert_rules"] = json.dumps(alert_rules_as_dict)
 
     def _set_unit_ip(self, _=None):
         """Set unit host address.

--- a/src/mimir_config.py
+++ b/src/mimir_config.py
@@ -114,7 +114,7 @@ class _S3ConfigData(BaseModel):
     @classmethod
     def set_insecure(cls, data: Any) -> Any:
         if isinstance(data, dict) and data.get("endpoint", None):
-            data["insecure"] = "true" if data["endpoint"].startswith("http://") else "false"
+            data["insecure"] = "false" if data["endpoint"].startswith("https://") else "true"
         return data
 
     @validator("endpoint")

--- a/src/mimir_config.py
+++ b/src/mimir_config.py
@@ -6,10 +6,10 @@
 import logging
 import re
 from dataclasses import asdict
-from typing import Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, model_validator, validator
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 S3_RELATION_NAME = "s3"
@@ -108,6 +108,14 @@ class _S3ConfigData(BaseModel):
     secret_access_key: str = Field(alias="secret-key")
     bucket_name: str = Field(alias="bucket")
     region: str = ""
+    insecure: str = "false"
+
+    @model_validator(mode="before")  # pyright: ignore
+    @classmethod
+    def set_insecure(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data.get("endpoint", None):
+            data["insecure"] = "true" if data["endpoint"].startswith("http://") else "false"
+        return data
 
     @validator("endpoint")
     def remove_scheme(cls, v: str) -> str:

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,7 @@ description = Run unit tests
 deps =
     pytest
     coverage[toml]
+    deepdiff
     -r{toxinidir}/requirements.txt
     
     # Binary deps from from charmcraft.yaml


### PR DESCRIPTION
This PR fixes #52.

`_S3ConfigData` now adds `insecure` field based on `endpoint` scheme