### PR TITLE
fix: correctly expand meta-roles when gathering addresses

### DIFF
--- a/src/mimir_cluster.py
+++ b/src/mimir_cluster.py
@@ -145,7 +145,7 @@ class MimirClusterProvider(Object):
                 try:
                     worker_data = MimirClusterRequirerUnitData.load(relation.data[worker_unit])
                     unit_address = worker_data.address
-                    for role in worker_roles:
+                    for role in expand_roles(worker_roles):
                         data[role].add(unit_address)
                 except DataValidationError as e:
                     log.info(f"invalid databag contents: {e}")


### PR DESCRIPTION
We apparently forgot to expand the meta roles, which we correctly do in the function above.