### PR TITLE
fix: Don't run nginx in daemon mode so pebble can manage it.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @abuelodelanada @dstathis @IbraAoad @lucabello @mmkay @pietropasotti @sed-i @simskij
+*       @canonical/Observability

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -19,7 +19,7 @@ resources:
   nginx-image:
     type: oci-image
     description: OCI image for nginx
-    upstream-source: ubuntu/nginx:1.18-22.04_beta
+    upstream-source: ubuntu/nginx:1.24-24.04_beta
   nginx-prometheus-exporter-image:
     type: oci-image
     description: OCI image for nginx-prometheus-exporter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,12 @@ max-complexity = 15
 # Allow Pydantic's `@validator` decorator to trigger class method treatment.
 classmethod-decorators = ["classmethod", "pydantic.validator"]
 
+[tool.codespell]
+skip = ".eggs,.tox,.git,.venv,venv,build,.build,lib,report,docs"
+quiet-level = 3
+check-filenames = true
+ignore-words-list = "assertIn"
+
 [tool.pyright]
 include = ["src"]
 extraPaths = ["lib"]

--- a/src/nginx.py
+++ b/src/nginx.py
@@ -273,7 +273,7 @@ class Nginx:
                     "nginx": {
                         "override": "replace",
                         "summary": "nginx",
-                        "command": "nginx",
+                        "command": "nginx -g 'daemon off;'",
                         "startup": "enabled",
                     }
                 },

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     ruff
 commands =
     black {[vars]all_path}
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
@@ -55,7 +55,7 @@ commands =
               --skip {toxinidir}/tox.ini \
               -L aNULL,anull
 
-    ruff {[vars]all_path}
+    ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm, lib}]


### PR DESCRIPTION
Also upgrade nginx to the latest image.

Fixes an error present in the pebble logs on nginx startup:

```
ubuntu@charm-dev:~$ juju ssh --container nginx mimir-coordinator-k8s/0
# bash      
root@mimir-coordinator-k8s-0:/# /charm/bin/pebble logs
2024-06-26T11:14:48.920Z [nginx] 2024/06/26 11:14:47 [emerg] 26#26: bind() to [::]:8080 failed (98: Unknown error)
2024-06-26T11:14:48.920Z [nginx] nginx: [emerg] bind() to [::]:8080 failed (98: Unknown error)
2024-06-26T11:14:49.420Z [nginx] 2024/06/26 11:14:47 [emerg] 26#26: bind() to 0.0.0.0:8080 failed (98: Unknown error)
2024-06-26T11:14:49.420Z [nginx] nginx: [emerg] bind() to 0.0.0.0:8080 failed (98: Unknown error)
```