### PR TITLE
fix: use leader units in integration tests, not unit 0

### DIFF
--- a/tests/integration/test_charm_ha.py
+++ b/tests/integration/test_charm_ha.py
@@ -32,11 +32,11 @@ async def test_build_and_deploy(ops_test: OpsTest, mimir_charm: str):
     assert ops_test.model is not None  # for pyright
     await asyncio.gather(
         ops_test.model.deploy(mimir_charm, "mimir", resources=charm_resources()),
-        ops_test.model.deploy("prometheus-k8s", "prometheus", channel="latest/edge"),
-        ops_test.model.deploy("loki-k8s", "loki", channel="latest/edge"),
-        ops_test.model.deploy("grafana-k8s", "grafana", channel="latest/edge"),
+        ops_test.model.deploy("prometheus-k8s", "prometheus", channel="latest/edge", trust=True),
+        ops_test.model.deploy("loki-k8s", "loki", channel="latest/edge", trust=True),
+        ops_test.model.deploy("grafana-k8s", "grafana", channel="latest/edge", trust=True),
         ops_test.model.deploy("grafana-agent-k8s", "agent", channel="latest/edge"),
-        ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge"),
+        ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge", trust=True),
         # Deploy and configure Minio and S3
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
         ops_test.model.deploy(

--- a/tests/integration/test_charm_ha_scaled.py
+++ b/tests/integration/test_charm_ha_scaled.py
@@ -31,11 +31,11 @@ async def test_build_and_deploy(ops_test: OpsTest, mimir_charm: str):
     assert ops_test.model is not None  # for pyright
     await asyncio.gather(
         ops_test.model.deploy(mimir_charm, "mimir", resources=charm_resources()),
-        ops_test.model.deploy("prometheus-k8s", "prometheus", channel="latest/edge"),
-        ops_test.model.deploy("loki-k8s", "loki", channel="latest/edge"),
-        ops_test.model.deploy("grafana-k8s", "grafana", channel="latest/edge"),
+        ops_test.model.deploy("prometheus-k8s", "prometheus", channel="latest/edge", trust=True),
+        ops_test.model.deploy("loki-k8s", "loki", channel="latest/edge", trust=True),
+        ops_test.model.deploy("grafana-k8s", "grafana", channel="latest/edge", trust=True),
         ops_test.model.deploy("grafana-agent-k8s", "agent", channel="latest/edge"),
-        ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge"),
+        ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge", trust=True),
         # Deploy and configure Minio and S3
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
         ops_test.model.deploy(

--- a/tests/integration/test_charm_monolithic.py
+++ b/tests/integration/test_charm_monolithic.py
@@ -31,11 +31,11 @@ async def test_build_and_deploy(ops_test: OpsTest, mimir_charm: str):
     assert ops_test.model is not None  # for pyright
     await asyncio.gather(
         ops_test.model.deploy(mimir_charm, "mimir", resources=charm_resources()),
-        ops_test.model.deploy("prometheus-k8s", "prometheus", channel="latest/edge"),
-        ops_test.model.deploy("loki-k8s", "loki", channel="latest/edge"),
-        ops_test.model.deploy("grafana-k8s", "grafana", channel="latest/edge"),
+        ops_test.model.deploy("prometheus-k8s", "prometheus", channel="latest/edge", trust=True),
+        ops_test.model.deploy("loki-k8s", "loki", channel="latest/edge", trust=True),
+        ops_test.model.deploy("grafana-k8s", "grafana", channel="latest/edge", trust=True),
         ops_test.model.deploy("grafana-agent-k8s", "agent", channel="latest/edge"),
-        ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge"),
+        ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge", trust=True),
         # Deploy and configure Minio and S3
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
         ops_test.model.deploy(


### PR DESCRIPTION
Previously, when the integration tests interacted with a unit of a deployed application they used the hardcoded unit 0.  This typically works, but sometimes tests would flake if an application did not have a unit 0 (maybe because 0 was killed and 1 was created). 

This change adds `get_leader_unit_number` to first determined the unit number of the leader unit, then uses that unit anywhere we previously used unit 0.  This should be more resilient while functionally equivalent (as before, we used unit 0 because that's typically the leader/only unit)

Also fixed here is some missing `trust=True` args in the integration tests.  Previously, integration tests did not include `trust=True` for applications that do require trust (eg: any that use lightkube).  This was not detected because automated CI runs are executed without RBAC enabled.  This is fixed by adding trust where required

Closes #71 