### PR TITLE
Add workload tracing to Mimir

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -24,6 +24,7 @@ parts:
     source: .
     build-packages:
       - curl
+      - git
     override-pull: |
       curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_TARGET_ARCH}
       chmod +x cos-tool-*

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -24,7 +24,6 @@ parts:
     source: .
     build-packages:
       - curl
-      - git
     override-pull: |
       curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_TARGET_ARCH}
       chmod +x cos-tool-*

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -56,11 +56,17 @@ requires:
     description: |
       Certificate and key files for securing Mimir communications with TLS.
 
-  tracing:
+  charm-tracing:
     interface: tracing
     limit: 1
     description: |
-      Enables sending traces to the tracing backend.
+      Enables sending charm traces to the tracing backend.
+
+  workload-tracing:
+    interface: tracing
+    limit: 1
+    description: |
+      Enables sending workload traces to the tracing backend.
 
 provides:
   mimir-cluster:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -60,13 +60,13 @@ requires:
     interface: tracing
     limit: 1
     description: |
-      Enables sending charm traces to the tracing backend.
+      Enables sending charm traces to a distributed tracing backend such as Tempo.
 
   workload-tracing:
     interface: tracing
     limit: 1
     description: |
-      Enables sending workload traces to the tracing backend.
+      Enables sending workload traces to a distributed tracing backend such as Tempo.
 
 provides:
   mimir-cluster:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops
-cosl
+cosl@git+https://github.com/canonical/cos-lib@OPENG-2902
 pydantic
 # crossplane is a package from nginxinc to interact with the Nginx config
 crossplane

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops
-cosl@git+https://github.com/canonical/cos-lib@OPENG-2902
+cosl>=0.0.43
 pydantic
 # crossplane is a package from nginxinc to interact with the Nginx config
 crossplane

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,7 +15,7 @@ import logging
 import os
 import shutil
 import socket
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import urlparse
 
 import cosl.coordinated_workers.nginx
@@ -23,6 +23,7 @@ import ops
 from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
 from charms.prometheus_k8s.v1.prometheus_remote_write import PrometheusRemoteWriteProvider
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
+from charms.tempo_coordinator_k8s.v0.tracing import charm_tracing_config
 from charms.traefik_k8s.v2.ingress import IngressPerAppReadyEvent, IngressPerAppRequirer
 from cosl.coordinated_workers.coordinator import Coordinator
 from ops.model import ModelError
@@ -39,8 +40,8 @@ CONSOLIDATED_ALERT_RULES_PATH = "./src/prometheus_alert_rules/consolidated_rules
 
 
 @trace_charm(
-    tracing_endpoint="tempo_endpoint",
-    server_cert="server_cert_path",
+    tracing_endpoint="charm_tracing_endpoint",
+    server_cert="server_ca_cert",
     extra_types=[
         Coordinator,
     ],
@@ -71,11 +72,17 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
                 "grafana-dashboards": "grafana-dashboards-provider",
                 "logging": "logging-consumer",
                 "metrics": "self-metrics-endpoint",
-                "tracing": "tracing",
+                "charm-tracing": "charm-tracing",
+                "workload-tracing": "workload-tracing",
                 "s3": "s3",
             },
             nginx_config=NginxConfig().config,
             workers_config=MimirConfig().config,
+            workload_tracing_protocols=["jaeger_thrift_http"],
+        )
+
+        self.charm_tracing_endpoint, self.server_ca_cert = charm_tracing_config(
+            self.coordi  grpc_tls_config: &id001nator.charm_tracing, cosl.coordinated_workers.nginx.CA_CERT_PATH
         )
 
         if port := urlparse(self.internal_url).port:
@@ -133,19 +140,6 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
     def hostname(self) -> str:
         """Unit's hostname."""
         return socket.getfqdn()
-
-    @property
-    def tempo_endpoint(self) -> Optional[str]:
-        """Tempo endpoint for charm tracing."""
-        if self.coordinator.tracing.is_ready():
-            return self.coordinator.tracing.get_endpoint(protocol="otlp_http")
-        else:
-            return None
-
-    @property
-    def server_cert_path(self) -> Optional[str]:
-        """Server certificate path for tls tracing."""
-        return cosl.coordinated_workers.nginx.CERT_PATH
 
     @property
     def internal_url(self) -> str:

--- a/src/charm.py
+++ b/src/charm.py
@@ -82,7 +82,7 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
         )
 
         self.charm_tracing_endpoint, self.server_ca_cert = charm_tracing_config(
-            self.coordi  grpc_tls_config: &id001nator.charm_tracing, cosl.coordinated_workers.nginx.CA_CERT_PATH
+            self.coordinator.charm_tracing, cosl.coordinated_workers.nginx.CA_CERT_PATH
         )
 
         if port := urlparse(self.internal_url).port:


### PR DESCRIPTION
## Issue
Enable sending Mimir's (workload) internal traces.

## Solution
- Enable `jaeger_thrift_http` protocol

## Drive-bys
Split `charm_tracing` and `workload_tracing`

## Context
https://github.com/canonical/cos-lib/pull/95

## Testing Instructions
1. Deploy Mimir HA solution with this [worker](https://github.com/canonical/mimir-worker-k8s-operator/pull/79)
2. Deploy grafana
3. integrate `mimir:grafana-source` with `grafana`
4. You'll find mimir's workload traces