### PR TITLE
[tf] Update the outputs.tf with endpoints nomenclature

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,7 +2,7 @@ output "app_name" {
   value = juju_application.mimir_coordinator.name
 }
 
-output "requires" {
+output "endpoints" {
   value = {
     mimir_cluster = "mimir-cluster"
   }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,6 +4,9 @@ output "app_name" {
 
 output "endpoints" {
   value = {
+    # Requires
+    
+    # Provides
     mimir_cluster = "mimir-cluster"
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -5,7 +5,6 @@ output "app_name" {
 output "endpoints" {
   value = {
     # Requires
-    
     # Provides
     mimir_cluster = "mimir-cluster"
   }

--- a/tests/integration/test_charm_ha.py
+++ b/tests/integration/test_charm_ha.py
@@ -41,7 +41,7 @@ async def test_build_and_deploy(ops_test: OpsTest, mimir_charm: str):
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
         ops_test.model.deploy(
             "minio",
-            channel="latest/stable",
+            channel="ckf-1.9/stable",
             config={"access-key": "access", "secret-key": "secretsecret"},
         ),
         ops_test.model.deploy("s3-integrator", "s3", channel="latest/stable"),

--- a/tests/integration/test_charm_ha_scaled.py
+++ b/tests/integration/test_charm_ha_scaled.py
@@ -40,7 +40,7 @@ async def test_build_and_deploy(ops_test: OpsTest, mimir_charm: str):
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
         ops_test.model.deploy(
             "minio",
-            channel="latest/stable",
+            channel="ckf-1.9/stable",
             config={"access-key": "access", "secret-key": "secretsecret"},
         ),
         ops_test.model.deploy("s3-integrator", "s3", channel="latest/stable"),

--- a/tests/integration/test_charm_monolithic.py
+++ b/tests/integration/test_charm_monolithic.py
@@ -40,7 +40,7 @@ async def test_build_and_deploy(ops_test: OpsTest, mimir_charm: str):
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
         ops_test.model.deploy(
             "minio",
-            channel="latest/stable",
+            channel="ckf-1.9/stable",
             config={"access-key": "access", "secret-key": "secretsecret"},
         ),
         ops_test.model.deploy("s3-integrator", "s3", channel="latest/stable"),


### PR DESCRIPTION
To remove implementation detail of the TF module when another module inherits it, it makes sense to replace the `requires` and `provides` output variables with `endpoints`.

Coordinating PR
- https://github.com/canonical/observability/pull/226