### PR TITLE
Implement grafana_datasource_exchange

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,11 @@ unit:
 		--capture=no \
 		$(TESTS)/unit \
 		$(ARGS)
-	uv run --frozen --isolated --extra dev \
-		coverage report
 	
 	uv run --frozen --isolated --extra dev \
 		coverage run \
 		--source=$(SRC) \
+		--append \
 		-m pytest \
 		--tb native \
 		--verbose \

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ fmt:
 	uv run --frozen --isolated --extra dev \
 		ruff format $(ALL)
 
-# Run unit and scenario tests
+# Run unit tests
 unit:
 	uv run --frozen --isolated --extra dev \
 		coverage run \

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ fmt:
 	uv run --frozen --isolated --extra dev \
 		ruff format $(ALL)
 
-# Run unit tests
+# Run unit and scenario tests
 unit:
 	uv run --frozen --isolated --extra dev \
 		coverage run \
@@ -43,6 +43,18 @@ unit:
 		--verbose \
 		--capture=no \
 		$(TESTS)/unit \
+		$(ARGS)
+	uv run --frozen --isolated --extra dev \
+		coverage report
+	
+	uv run --frozen --isolated --extra dev \
+		coverage run \
+		--source=$(SRC) \
+		-m pytest \
+		--tb native \
+		--verbose \
+		--capture=no \
+		$(TESTS)/scenario \
 		$(ARGS)
 	uv run --frozen --isolated --extra dev \
 		coverage report
@@ -57,18 +69,6 @@ integration:
 		--tb native \
 		--log-cli-level=INFO \
 		$(TESTS)/integration \
-		$(ARGS)
-
-# Run scenario tests
-scenario:
-	uv run --frozen --isolated --extra dev \
-		pytest \
-		--verbose \
-		--exitfirst \
-		--capture=no \
-		--tb native \
-		--log-cli-level=INFO \
-		$(TESTS)/scenario \
 		$(ARGS)
 
 # Run interface tests

--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,27 @@ integration:
 		--log-cli-level=INFO \
 		$(TESTS)/integration \
 		$(ARGS)
+
+# Run scenario tests
+scenario:
+	uv run --frozen --isolated --extra dev \
+		pytest \
+		--verbose \
+		--exitfirst \
+		--capture=no \
+		--tb native \
+		--log-cli-level=INFO \
+		$(TESTS)/scenario \
+		$(ARGS)
+
+# Run interface tests
+interface:
+	uv run --frozen --isolated --extra dev \
+		pytest \
+		--verbose \
+		--exitfirst \
+		--capture=no \
+		--tb native \
+		--log-cli-level=INFO \
+		$(TESTS)/interface \
+		$(ARGS)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -96,3 +96,9 @@ provides:
     interface: prometheus_scrape
     description: |
       The coordinator provides scrape jobs for itself and for the workers.
+
+  send-datasource:
+    interface: grafana_datasource_exchange
+    description: |
+      Integration to share with other COS components this charm's datasources, and receive theirs.
+      

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "crossplane",
 
     # ---PYDEPS---
-    "cosl>=0.0.43",
+    "cosl>=0.0.47",
     "pydantic>=2",
     # lib/charms/tempo_k8s/v1/charm_tracing.py
     "opentelemetry-exporter-otlp-proto-http==1.21.0",
@@ -34,6 +34,10 @@ dev = [
   "tenacity",
   "juju",
   "pytest-operator",
+  # scenario
+  "ops[testing]>=2.17",
+  # interface
+  "pytest-interface-tester>2.0.0",
 ]
 
 # Testing tools configuration

--- a/src/charm.py
+++ b/src/charm.py
@@ -24,7 +24,7 @@ from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
 from charms.prometheus_k8s.v1.prometheus_remote_write import PrometheusRemoteWriteProvider
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
 from charms.tempo_coordinator_k8s.v0.tracing import charm_tracing_config
-from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
+from charms.traefik_k8s.v2.ingress import IngressPerAppReadyEvent, IngressPerAppRequirer
 from cosl.coordinated_workers.coordinator import Coordinator
 from cosl.interfaces.datasource_exchange import DatasourceDict
 from ops.model import ModelError
@@ -128,12 +128,14 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
 
     def _on_ingress_ready(self, event: IngressPerAppReadyEvent):
         """Log the obtained ingress address.
+
         This event refreshes the PrometheusRemoteWriteProvider address.
         """
         logger.info("Ingress for app ready on '%s'", event.url)
 
     def _on_ingress_revoked(self, _) -> None:
         """Log the ingress address being revoked.
+
         This event refreshes the PrometheusRemoteWriteProvider address.
         """
         logger.info("Ingress for app revoked")

--- a/src/charm.py
+++ b/src/charm.py
@@ -24,7 +24,7 @@ from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
 from charms.prometheus_k8s.v1.prometheus_remote_write import PrometheusRemoteWriteProvider
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
 from charms.tempo_coordinator_k8s.v0.tracing import charm_tracing_config
-from charms.traefik_k8s.v2.ingress import IngressPerAppReadyEvent, IngressPerAppRequirer
+from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
 from cosl.coordinated_workers.coordinator import Coordinator
 from cosl.interfaces.datasource_exchange import DatasourceDict
 from ops.model import ModelError
@@ -113,40 +113,8 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
             endpoint_path="/api/v1/push",
         )
 
-        if self._nginx_container.can_connect():
-            self._set_alerts()
-
         # do this regardless of what event we are processing
         self._reconcile()
-
-        ######################################
-        # === EVENT HANDLER REGISTRATION === #
-        ######################################
-        self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
-        self.framework.observe(self.ingress.on.revoked, self._on_ingress_revoked)
-        self.framework.observe(self.on.nginx_pebble_ready, self._on_pebble_ready)
-
-    ##########################
-    # === EVENT HANDLERS === #
-    ##########################
-
-    def _on_ingress_ready(self, event: IngressPerAppReadyEvent):
-        """Log the obtained ingress address.
-
-        This event refreshes the PrometheusRemoteWriteProvider address.
-        """
-        logger.info("Ingress for app ready on '%s'", event.url)
-
-    def _on_ingress_revoked(self, _) -> None:
-        """Log the ingress address being revoked.
-
-        This event refreshes the PrometheusRemoteWriteProvider address.
-        """
-        logger.info("Ingress for app revoked")
-
-    def _on_pebble_ready(self, _) -> None:
-        """Make sure the `mimirtool` binary is in the workload container."""
-        self._ensure_mimirtool()
 
     ######################
     # === PROPERTIES === #
@@ -286,6 +254,9 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
         # regardless of the event we are processing.
         # reason is, if we miss these events because our coordinator cannot process events (inconsistent status),
         # we need to 'remember' to run this logic as soon as we become ready, which is hard and error-prone
+        if self._nginx_container.can_connect():
+            self._set_alerts()
+        self._ensure_mimirtool()
         self._update_datasource_exchange()
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -252,8 +252,6 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
     def _reconcile(self):
         # This method contains unconditional update logic, i.e. logic that should be executed
         # regardless of the event we are processing.
-        # reason is, if we miss these events because our coordinator cannot process events (inconsistent status),
-        # we need to 'remember' to run this logic as soon as we become ready, which is hard and error-prone
         if self._nginx_container.can_connect():
             self._set_alerts()
         self._ensure_mimirtool()

--- a/src/charm.py
+++ b/src/charm.py
@@ -116,6 +116,28 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
         # do this regardless of what event we are processing
         self._reconcile()
 
+        ######################################
+        # === EVENT HANDLER REGISTRATION === #
+        ######################################
+        self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
+        self.framework.observe(self.ingress.on.revoked, self._on_ingress_revoked)
+
+    ##########################
+    # === EVENT HANDLERS === #
+    ##########################
+
+    def _on_ingress_ready(self, event: IngressPerAppReadyEvent):
+        """Log the obtained ingress address.
+        This event refreshes the PrometheusRemoteWriteProvider address.
+        """
+        logger.info("Ingress for app ready on '%s'", event.url)
+
+    def _on_ingress_revoked(self, _) -> None:
+        """Log the ingress address being revoked.
+        This event refreshes the PrometheusRemoteWriteProvider address.
+        """
+        logger.info("Ingress for app revoked")
+
     ######################
     # === PROPERTIES === #
     ######################

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -1,0 +1,140 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import json
+import socket
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import pytest
+from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
+from cosl.coordinated_workers.interface import (
+    ClusterRequirerAppData,
+    ClusterRequirerUnitData,
+)
+from interface_tester import InterfaceTester
+from ops import ActiveStatus
+from ops.pebble import Layer
+from scenario import Relation
+from scenario.state import Container, Exec, State
+
+from charm import MimirCoordinatorK8SOperatorCharm
+
+nginx_container = Container(
+    name="nginx",
+    can_connect=True,
+    layers={
+        "foo": Layer(
+            {
+                "summary": "foo",
+                "description": "bar",
+                "services": {
+                    "nginx": {
+                        "startup": "enabled",
+                        "current": "active",
+                        "name": "nginx",
+                    }
+                },
+                "checks": {},
+            }
+        )
+    },
+    execs={
+        Exec(
+            [
+                "mimirtool",
+                "rules",
+                "sync",
+                f"--address=http://{socket.getfqdn()}:8080",
+                "--id=anonymous",
+            ],
+            return_code=0,
+        )
+    },
+)
+
+nginx_prometheus_exporter_container = Container(
+    name="nginx-prometheus-exporter",
+    can_connect=True,
+)
+
+s3_relation = Relation(
+    "s3",
+    remote_app_data={
+        "access-key": "key",
+        "bucket": "mimir",
+        "endpoint": "http://1.2.3.4:9000",
+        "secret-key": "soverysecret",
+    },
+)
+cluster_relation = Relation(
+    "mimir-cluster",
+    remote_app_data=ClusterRequirerAppData(role="all").dump(),
+    remote_units_data={
+        0: ClusterRequirerUnitData(
+            address="http://example.com",
+            juju_topology={"application": "app", "unit": "unit", "charm_name": "charmname"},
+        ).dump()
+    },
+)
+
+grafana_source_relation = Relation(
+    "grafana-source",
+    remote_app_data={"datasources": json.dumps({"mimir/0": {"type": "mimir", "uid": "01234"}})},
+)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def patch_all():
+    with ExitStack() as stack:
+        stack.enter_context(patch("lightkube.core.client.GenericSyncClient"))
+        stack.enter_context(
+            patch.multiple(
+                "charms.observability_libs.v0.kubernetes_compute_resources_patch.KubernetesComputeResourcesPatch",
+                _namespace="test-namespace",
+                _patch=lambda _: None,
+                is_ready=MagicMock(return_value=True),
+                get_status=lambda _: ActiveStatus(""),
+            )
+        )
+        stack.enter_context(charm_tracing_disabled())
+        stack.enter_context(
+            patch(
+                "charm.MimirCoordinatorK8SOperatorCharm._ensure_mimirtool",
+                MagicMock(return_value=None),
+            )
+        )
+        yield
+
+
+# Interface tests are centrally hosted at https://github.com/canonical/charm-relation-interfaces.
+# this fixture is used by the test runner of charm-relation-interfaces to test mimir's compliance
+# with the interface specifications.
+# DO NOT MOVE OR RENAME THIS FIXTURE! If you need to, you'll need to open a PR on
+# https://github.com/canonical/charm-relation-interfaces and change mimir's test configuration
+# to include the new identifier/location.
+
+
+@pytest.fixture
+def grafana_datasource_tester(interface_tester: InterfaceTester):
+    interface_tester.configure(
+        charm_type=MimirCoordinatorK8SOperatorCharm,
+        state_template=State(
+            leader=True,
+            containers=[nginx_container, nginx_prometheus_exporter_container],
+            relations=[s3_relation, cluster_relation],
+        ),
+    )
+    yield interface_tester
+
+
+@pytest.fixture
+def grafana_datasource_exchange_tester(interface_tester: InterfaceTester):
+    interface_tester.configure(
+        charm_type=MimirCoordinatorK8SOperatorCharm,
+        state_template=State(
+            leader=True,
+            containers=[nginx_container, nginx_prometheus_exporter_container],
+            relations=[s3_relation, cluster_relation, grafana_source_relation],
+        ),
+    )
+    yield interface_tester

--- a/tests/interface/test_grafana_datasource_exchange.py
+++ b/tests/interface/test_grafana_datasource_exchange.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+from interface_tester import InterfaceTester
+
+
+def test_grafana_datasource_exchange_v0_interface(
+    grafana_datasource_exchange_tester: InterfaceTester,
+):
+    grafana_datasource_exchange_tester.configure(
+        interface_name="grafana_datasource_exchange",
+        interface_version=0,
+    )
+    grafana_datasource_exchange_tester.run()

--- a/tests/interface/test_grafana_source.py
+++ b/tests/interface/test_grafana_source.py
@@ -1,0 +1,11 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+from interface_tester import InterfaceTester
+
+
+def test_grafana_datasource_v0_interface(grafana_datasource_tester: InterfaceTester):
+    grafana_datasource_tester.configure(
+        interface_name="grafana_datasource",
+        interface_version=0,
+    )
+    grafana_datasource_tester.run()

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -1,0 +1,104 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import socket
+from unittest.mock import MagicMock, patch
+
+import pytest
+from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
+from ops import ActiveStatus
+from scenario import Container, Context, Exec, Relation
+
+from charm import MimirCoordinatorK8SOperatorCharm
+
+
+@pytest.fixture(autouse=True, scope="session")
+def disable_charm_tracing():
+    with charm_tracing_disabled():
+        yield
+
+
+@pytest.fixture
+def mimir_charm(tmp_path):
+    with patch("lightkube.core.client.GenericSyncClient"):
+        with patch.multiple(
+            "cosl.coordinated_workers.coordinator.KubernetesComputeResourcesPatch",
+            _namespace="test-namespace",
+            _patch=lambda _: None,
+            get_status=lambda _: ActiveStatus(""),
+            is_ready=lambda _: True,
+        ):
+            with patch(
+                "charm.MimirCoordinatorK8SOperatorCharm._ensure_mimirtool",
+                MagicMock(return_value=None),
+            ):
+                yield MimirCoordinatorK8SOperatorCharm
+
+
+@pytest.fixture(scope="function")
+def context(mimir_charm):
+    return Context(charm_type=mimir_charm)
+
+
+@pytest.fixture(scope="function")
+def nginx_container():
+    return Container(
+        "nginx",
+        can_connect=True,
+        execs={
+            Exec(
+                [
+                    "mimirtool",
+                    "rules",
+                    "sync",
+                    f"--address=http://{socket.getfqdn()}:8080",
+                    "--id=anonymous",
+                ],
+                return_code=0,
+            )
+        },
+    )
+
+
+@pytest.fixture(scope="function")
+def nginx_prometheus_exporter_container():
+    return Container(
+        "nginx-prometheus-exporter",
+        can_connect=True,
+    )
+
+
+@pytest.fixture(scope="function")
+def s3_config():
+    return {
+        "access-key": "key",
+        "bucket": "mimir",
+        "endpoint": "http://1.2.3.4:9000",
+        "secret-key": "soverysecret",
+    }
+
+
+@pytest.fixture(scope="function")
+def s3(s3_config):
+    return Relation(
+        "s3",
+        remote_app_data=s3_config,
+        local_unit_data={"bucket": "mimir"},
+    )
+
+
+@pytest.fixture(scope="function")
+def all_worker():
+    return Relation(
+        "mimir-cluster",
+        remote_app_data={"role": '"all"'},
+        remote_units_data={
+            0: {
+                "address": json.dumps("localhost"),
+                "juju_topology": json.dumps(
+                    {"application": "worker", "unit": "worker/0", "charm_name": "mimir"}
+                ),
+            }
+        },
+    )

--- a/tests/scenario/test_datasources.py
+++ b/tests/scenario/test_datasources.py
@@ -1,0 +1,86 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+
+import scenario
+from cosl.interfaces.datasource_exchange import (
+    DatasourceExchange,
+    DSExchangeAppData,
+    GrafanaDatasource,
+)
+from scenario import Relation, State
+
+
+def test_datasource_send(
+    context,
+    s3,
+    all_worker,
+    nginx_container,
+    nginx_prometheus_exporter_container,
+):
+    # GIVEN a regular HA deployment and two ds_exchange integrations with a tempo and a loki
+    ds_tempo = [
+        {"type": "tempo", "uid": "3", "grafana_uid": "4"},
+    ]
+
+    ds_loki = [
+        {"type": "loki", "uid": "8", "grafana_uid": "9"},
+    ]
+
+    loki_dsx = Relation(
+        "send-datasource",
+        remote_app_data=DSExchangeAppData(
+            datasources=json.dumps(sorted(ds_loki, key=lambda raw_ds: raw_ds["uid"]))
+        ).dump(),
+    )
+    tempo_dsx = Relation(
+        "send-datasource",
+        remote_app_data=DSExchangeAppData(
+            datasources=json.dumps(sorted(ds_tempo, key=lambda raw_ds: raw_ds["uid"]))
+        ).dump(),
+    )
+
+    ds = Relation(
+        "grafana-source",
+        remote_app_data={
+            "grafana_uid": "foo-something-bars",
+            "datasource_uids": json.dumps({"mimir/0": "1234"}),
+        },
+    )
+
+    state_in = State(
+        relations=[
+            s3,
+            all_worker,
+            ds,
+            loki_dsx,
+            tempo_dsx,
+        ],
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+        unit_status=scenario.ActiveStatus(),
+        leader=True,
+    )
+
+    # WHEN we receive any event
+    with context(context.on.update_status(), state_in) as mgr:
+        charm = mgr.charm
+        # THEN we can find all received datasource uids in the coordinator
+        dsx: DatasourceExchange = charm.coordinator.datasource_exchange
+        received = dsx.received_datasources
+        assert received == (
+            GrafanaDatasource(type="tempo", uid="3", grafana_uid="4"),
+            GrafanaDatasource(type="loki", uid="8", grafana_uid="9"),
+        )
+        state_out = mgr.run()
+
+    # AND THEN we forward our own datasource information to tempo and loki
+    assert state_out.unit_status.name == "active"
+    published_dsx_loki = state_out.get_relation(loki_dsx.id).local_app_data
+    published_dsx_tempo = state_out.get_relation(tempo_dsx.id).local_app_data
+    assert published_dsx_tempo == published_dsx_loki
+    assert json.loads(published_dsx_tempo["datasources"])[0] == {
+        "type": "prometheus",
+        "uid": "1234",
+        "grafana_uid": "foo-something-bars",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -192,6 +192,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.1.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "platform_system == 'Windows'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28", size = 97941 },
+]
+
+[[package]]
 name = "codespell"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -211,7 +223,7 @@ wheels = [
 
 [[package]]
 name = "cosl"
-version = "0.0.45"
+version = "0.0.47"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lightkube" },
@@ -221,9 +233,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/fa/9f6354042ce1e05c02b9bb0d7c02518e5667e36f454bcc7114413f34b158/cosl-0.0.45.tar.gz", hash = "sha256:0e7db33091f9694666a485bba8e21ddf79ff69f2f86002c855aa58b08a561a95", size = 67487 }
+sdist = { url = "https://files.pythonhosted.org/packages/60/d0/03c623606f0bbcb6dd2529efbdc280be4e4bcb9871dab6c4a2673e31e90f/cosl-0.0.47.tar.gz", hash = "sha256:42aaa2fcda3c73b5f52076e6790356642f9acaefdc1a49b1379395e8978f0c98", size = 70915 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/9a/6a9d94e903642c6815bf2967736b09b5cc5c627e8e9656517b79640b7d16/cosl-0.0.45-py3-none-any.whl", hash = "sha256:aede0ff7238f6e84f8ff69e32b0f0fd69dd049a1d1b922b9e9166c8ce9a443ea", size = 54702 },
+    { url = "https://files.pythonhosted.org/packages/b9/40/3bc2c06845a2ad90cc56882c9d94df73069683ccb9d65a7c0115cc401298/cosl-0.0.47-py3-none-any.whl", hash = "sha256:469e0760773322ffe45554bb5545e9f673fcef501345c8d0b15c9456af6712eb", size = 58434 },
 ]
 
 [[package]]
@@ -274,7 +286,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/65/13d9e76ca19b0ba5603d71ac8424b5694415b348e719db277b5edc985ff5/cryptography-44.0.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:761817a3377ef15ac23cd7834715081791d4ec77f9297ee694ca1ee9c2c7e5eb", size = 3915420 },
     { url = "https://files.pythonhosted.org/packages/b1/07/40fe09ce96b91fc9276a9ad272832ead0fddedcba87f1190372af8e3039c/cryptography-44.0.0-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3c672a53c0fb4725a29c303be906d3c1fa99c32f58abe008a82705f9ee96f40b", size = 4154498 },
     { url = "https://files.pythonhosted.org/packages/75/ea/af65619c800ec0a7e4034207aec543acdf248d9bffba0533342d1bd435e1/cryptography-44.0.0-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:4ac4c9f37eba52cb6fbeaf5b59c152ea976726b865bd4cf87883a7e7006cc543", size = 3932569 },
-    { url = "https://files.pythonhosted.org/packages/4e/d5/9cc182bf24c86f542129565976c21301d4ac397e74bf5a16e48241aab8a6/cryptography-44.0.0-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:60eb32934076fa07e4316b7b2742fa52cbb190b42c2df2863dbc4230a0a9b385", size = 4164756 },
     { url = "https://files.pythonhosted.org/packages/c7/af/d1deb0c04d59612e3d5e54203159e284d3e7a6921e565bb0eeb6269bdd8a/cryptography-44.0.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ed3534eb1090483c96178fcb0f8893719d96d5274dfde98aa6add34614e97c8e", size = 4016721 },
     { url = "https://files.pythonhosted.org/packages/bd/69/7ca326c55698d0688db867795134bdfac87136b80ef373aaa42b225d6dd5/cryptography-44.0.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f3f6fdfa89ee2d9d496e2c087cebef9d4fcbb0ad63c40e821b39f74bf48d9c5e", size = 4240915 },
     { url = "https://files.pythonhosted.org/packages/ef/d4/cae11bf68c0f981e0413906c6dd03ae7fa864347ed5fac40021df1ef467c/cryptography-44.0.0-cp37-abi3-win32.whl", hash = "sha256:eb33480f1bad5b78233b0ad3e1b0be21e8ef1da745d8d2aecbb20671658b9053", size = 2757925 },
@@ -285,7 +296,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/c7/c656eb08fd22255d21bc3129625ed9cd5ee305f33752ef2278711b3fa98b/cryptography-44.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c5eb858beed7835e5ad1faba59e865109f3e52b3783b9ac21e7e47dc5554e289", size = 3915417 },
     { url = "https://files.pythonhosted.org/packages/ef/82/72403624f197af0db6bac4e58153bc9ac0e6020e57234115db9596eee85d/cryptography-44.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f53c2c87e0fb4b0c00fa9571082a057e37690a8f12233306161c8f4b819960b7", size = 4155160 },
     { url = "https://files.pythonhosted.org/packages/a2/cd/2f3c440913d4329ade49b146d74f2e9766422e1732613f57097fea61f344/cryptography-44.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:9e6fc8a08e116fb7c7dd1f040074c9d7b51d74a8ea40d4df2fc7aa08b76b9e6c", size = 3932331 },
-    { url = "https://files.pythonhosted.org/packages/31/d9/90409720277f88eb3ab72f9a32bfa54acdd97e94225df699e7713e850bd4/cryptography-44.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9abcc2e083cbe8dde89124a47e5e53ec38751f0d7dfd36801008f316a127d7ba", size = 4165207 },
     { url = "https://files.pythonhosted.org/packages/7f/df/8be88797f0a1cca6e255189a57bb49237402b1880d6e8721690c5603ac23/cryptography-44.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d2436114e46b36d00f8b72ff57e598978b37399d2786fd39793c36c6d5cb1c64", size = 4017372 },
     { url = "https://files.pythonhosted.org/packages/af/36/5ccc376f025a834e72b8e52e18746b927f34e4520487098e283a719c205e/cryptography-44.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a01956ddfa0a6790d594f5b34fc1bfa6098aca434696a03cfdbe469b8ed79285", size = 4239657 },
     { url = "https://files.pythonhosted.org/packages/46/b0/f4f7d0d0bcfbc8dd6296c1449be326d04217c57afb8b2594f017eed95533/cryptography-44.0.0-cp39-abi3-win32.whl", hash = "sha256:eca27345e1214d1b9f9490d200f9db5a874479be914199194e746c893788d417", size = 2758672 },
@@ -677,8 +687,10 @@ dev = [
     { name = "deepdiff" },
     { name = "juju" },
     { name = "minio" },
+    { name = "ops", extra = ["testing"] },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-interface-tester" },
     { name = "pytest-operator" },
     { name = "ruff" },
     { name = "tenacity" },
@@ -687,7 +699,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "codespell", marker = "extra == 'dev'" },
-    { name = "cosl", specifier = ">=0.0.43" },
+    { name = "cosl", specifier = ">=0.0.47" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "crossplane" },
     { name = "cryptography" },
@@ -697,9 +709,11 @@ requires-dist = [
     { name = "minio", marker = "extra == 'dev'" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = "==1.21.0" },
     { name = "ops" },
+    { name = "ops", extras = ["testing"], marker = "extra == 'dev'", specifier = ">=2.17" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.344" },
     { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-interface-tester", marker = "extra == 'dev'", specifier = ">2.0.0" },
     { name = "pytest-operator", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "tenacity", marker = "extra == 'dev'" },
@@ -839,6 +853,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d8/e7/86d1a22d0f2066deadbc6da3d73380e5e7e6da20b95108a7cdbe40f5c444/ops-2.17.1.tar.gz", hash = "sha256:de2d1dd382b4a5f3df3ba78a5266d59462644f3f8ea0f4e7479a248998862a3f", size = 477569 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/db/3f9884051be5df318e3f1d9e67737295b34d045a135147de8a49afa88f9b/ops-2.17.1-py3-none-any.whl", hash = "sha256:0fabc45740d59619c3265328f51f71f99b06557e22493cdd32d10c2b25bcd553", size = 176831 },
+]
+
+[package.optional-dependencies]
+testing = [
+    { name = "ops-scenario" },
+]
+
+[[package]]
+name = "ops-scenario"
+version = "7.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ops" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ee/59323da3ea693f6e1001f30c600dcd5cdb7703c5b79a684c3379327bf8f9/ops_scenario-7.0.5.tar.gz", hash = "sha256:7ef7af6d026a29f93d54f394f6757170317a85cbfa755dab1303b94610a29b82", size = 260175 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/94/aa9b6f5cce795583820c4bbffa50df5c4245095b92e075930f4cb42b0021/ops_scenario-7.0.5-py3-none-any.whl", hash = "sha256:9f06c1989a62181e4952cbfe2002cbaa1290dc1d203245a6b1ce2f96e132615b", size = 74106 },
 ]
 
 [[package]]
@@ -1144,6 +1176,21 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-interface-tester"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ops-scenario" },
+    { name = "pydantic" },
+    { name = "pytest" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/e9/72d5367ac93bec47927736039aa9dd231d901c8bd33bf054b65d10f99039/pytest_interface_tester-3.3.0.tar.gz", hash = "sha256:98958ce13013f293eebfc72f3969d39a9b04f12b3923bac97bba6eef4de72288", size = 27413 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/c5/1f92f5a9bfeab22e662599a569e81aff53c82b4ecc47d17d592fea7cce2e/pytest_interface_tester-3.3.0-py3-none-any.whl", hash = "sha256:0c90e3879b08418f371f9028a4c574383e974c4647314811976990b290946775", size = 21584 },
+]
+
+[[package]]
 name = "pytest-operator"
 version = "0.38.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1375,6 +1422,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359 },
+]
+
+[[package]]
+name = "typer"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/45/bcbc581f87c8d8f2a56b513eb994d07ea4546322818d95dc6a3caf2c928b/typer-0.7.0.tar.gz", hash = "sha256:ff797846578a9f2a201b53442aedeb543319466870fbe1c701eab66dd7681165", size = 251871 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/44/56c3f48d2bb83d76f5c970aef8e2c3ebd6a832f09e3621c5395371fe6999/typer-0.7.0-py3-none-any.whl", hash = "sha256:b5e704f4e48ec263de1c0b3a2387cd405a13767d2f907f44c1a08cbad96f606d", size = 38377 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
Add a `send-datasource` endpoint to exchange datasource UIDs with other COS components.

## Testing Instructions
1. Deploy Mimir HA
2. Deploy `grafana-k8s`
3. Deploy Tempo HA
4. Integrate `tempo` and `grafana` over `grafana_datasource`
5. Integrate `mimir` and `grafana` over `grafana_datasource`
6. Integrate `mimir` and `tempo` over `grafana_datasource_exchange`
7. `jhack show-relation mimir tempo` and observe the datasource UID of `mimir` shared to `tempo` 

## Drive-bys
- Add interface and scenario tests