### PR TITLE
Enable/Disable IPv6-related nginx config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,21 +1,21 @@
 [project]
 name = "mimir-coordinator-k8s"
-version = "0.0"  # this is in fact irrelevant
-requires-python = "==3.10.*"  # https://packages.ubuntu.com/jammy/python3
+version = "0.0"                # this is in fact irrelevant
+requires-python = "==3.10.*"   # https://packages.ubuntu.com/jammy/python3
 
 dependencies = [
-    "ops",
-    # crossplane is a package from nginxinc to interact with the Nginx config
-    "crossplane",
+  "ops",
+  # crossplane is a package from nginxinc to interact with the Nginx config
+  "crossplane",
 
-    # ---PYDEPS---
-    "cosl>=0.0.47",
-    "pydantic>=2",
-    # lib/charms/tempo_k8s/v1/charm_tracing.py
-    "opentelemetry-exporter-otlp-proto-http==1.21.0",
-    # lib/charms/tls_certificates_interface/v3/tls_certificates.py
-    "jsonschema",
-    "cryptography",
+  # ---PYDEPS---
+  "cosl>=0.0.55",
+  "pydantic>=2",
+  # lib/charms/tempo_k8s/v1/charm_tracing.py
+  "opentelemetry-exporter-otlp-proto-http==1.21.0",
+  # lib/charms/tls_certificates_interface/v3/tls_certificates.py
+  "jsonschema",
+  "cryptography",
 ]
 
 [project.optional-dependencies]
@@ -51,9 +51,7 @@ show_missing = true
 asyncio_mode = "auto"
 minversion = "6.0"
 log_cli_level = "INFO"
-markers = [
-  'setup: marks tests as setup (deselect with -m "not setup")'
-]
+markers = ['setup: marks tests as setup (deselect with -m "not setup")']
 
 # Linting tools configuration
 [tool.ruff]
@@ -76,7 +74,7 @@ extend-ignore = [
   "D413",
 ]
 ignore = ["E501", "D107"]
-per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+per-file-ignores = { "tests/*" = ["D100", "D101", "D102", "D103", "D104"] }
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/charm.py
+++ b/src/charm.py
@@ -80,7 +80,6 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
                 "s3": "s3",
                 "send-datasource": "send-datasource",
                 "receive-datasource": None,
-                "catalogue": None,
             },
             nginx_config=NginxConfig().config,
             workers_config=MimirConfig(

--- a/src/charm.py
+++ b/src/charm.py
@@ -80,6 +80,7 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
                 "s3": "s3",
                 "send-datasource": "send-datasource",
                 "receive-datasource": None,
+                "catalogue": None,
             },
             nginx_config=NginxConfig().config,
             workers_config=MimirConfig(

--- a/src/nginx_config.py
+++ b/src/nginx_config.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Set
 
 import crossplane
 from cosl.coordinated_workers.coordinator import Coordinator
-from cosl.coordinated_workers.nginx import CERT_PATH, KEY_PATH
+from cosl.coordinated_workers.nginx import CERT_PATH, KEY_PATH, is_ipv6_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -194,6 +194,7 @@ class NginxConfig:
 
     def __init__(self):
         self.dns_IP_address = _get_dns_ip_address()
+        self.ipv6_enabled = is_ipv6_enabled()
 
     def config(self, coordinator: Coordinator) -> str:
         """Build and return the Nginx configuration."""
@@ -341,8 +342,7 @@ class NginxConfig:
                 "directive": "server",
                 "args": [],
                 "block": [
-                    {"directive": "listen", "args": ["443", "ssl"]},
-                    {"directive": "listen", "args": ["[::]:443", "ssl"]},
+                    *self._listen(443, ssl=True),
                     *self._basic_auth(auth_enabled),
                     {
                         "directive": "proxy_set_header",
@@ -365,8 +365,7 @@ class NginxConfig:
             "directive": "server",
             "args": [],
             "block": [
-                {"directive": "listen", "args": [f"{nginx_port}"]},
-                {"directive": "listen", "args": [f"[::]:{nginx_port}"]},
+                *self._listen(nginx_port, ssl=False),
                 *self._basic_auth(auth_enabled),
                 {
                     "directive": "proxy_set_header",
@@ -376,6 +375,23 @@ class NginxConfig:
                 *self._locations(addresses_by_role, tls),
             ],
         }
+
+    def _listen(self, port: int, ssl: bool) -> List[Dict[str, Any]]:
+        directives = []
+        directives.append({"directive": "listen", "args": self._listen_args(port, False, ssl)})
+        if self.ipv6_enabled:
+            directives.append({"directive": "listen", "args": self._listen_args(port, True, ssl)})
+        return directives
+
+    def _listen_args(self, port: int, ipv6: bool, ssl: bool) -> List[str]:
+        args = []
+        if ipv6:
+            args.append(f"[::]:{port}")
+        else:
+            args.append(f"{port}")
+        if ssl:
+            args.append("ssl")
+        return args
 
 
 def _get_dns_ip_address():


### PR DESCRIPTION
## Issue
Fixes https://github.com/canonical/cos-lib/issues/127

## Solution
Use https://github.com/canonical/cos-lib/pull/128 utility to check if ipv6 is enabled and listen to the ipv6 addresses accordingly.

## Context
https://github.com/canonical/cos-lib/pull/128

## Testing Instructions
1. [Disable](https://www.techrepublic.com/article/how-to-disable-ipv6-through-grub-in-linux/) ipv6 on the host machine
2. Reboot your machine
3. Deploy Mimir HA
4. Mimir coordinator should be in active/idle and if you juju ssh --container nginx tempo/0 ss -utpln, you should not see nginx listening on any ipv6 addresses.
