### PR TITLE
fix: update prometheus-api url to point to /prometheus endpoint

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -110,4 +110,5 @@ provides:
   prometheus-api:
     interface: prometheus_api
     description: |
-      The integration point for other charms to consume Mimir's Prometheus API, for example so they can query Mimir.
+      The integration point for other charms to consume Mimir's Prometheus API, for example so they can query Mimir.  
+      This sends one or more URLs that can be consumed by anything that can consume the Prometheus API.

--- a/src/charm.py
+++ b/src/charm.py
@@ -300,8 +300,8 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
             relation_name=PROMETHEUS_API_RELATION_NAME,
         )
         prometheus_api.publish(
-            direct_url=self.internal_url,
-            ingress_url=self.external_url,
+            direct_url=f"{self.internal_url}/prometheus",
+            ingress_url=f"{self.external_url}/prometheus" if self.external_url else None,
         )
 
     def _update_datasource_exchange(self) -> None:

--- a/tests/scenario/test_prometheus_api_implementation.py
+++ b/tests/scenario/test_prometheus_api_implementation.py
@@ -8,14 +8,8 @@ from ops.testing import Relation, State
 RELATION_NAME = "prometheus-api"
 INTERFACE_NAME = "prometheus_api"
 
-# Note: if this is changed, the PrometheusApiAppData concrete classes below need to change their constructors to match
-SAMPLE_APP_DATA = {
-    "ingress_url": "http://www.ingress-url.com/",
-    "direct_url": "http://www.internal-url.com/",
-}
-
-MIMIR_URL = "http://internal.com/"
-MIMIR_INGRESS_URL = "http://www.ingress-url.com/"
+MIMIR_URL = "http://internal.com"
+MIMIR_INGRESS_URL = "http://www.ingress-url.com"
 
 
 def local_app_data_relation_state(
@@ -63,7 +57,7 @@ def test_provider_sender_sends_data_on_relation_joined(
     with context(context.on.relation_joined(prometheus_api), state=state) as manager:
         state_out = manager.run()
         expected = {
-            "direct_url": MIMIR_URL,
+            "direct_url": f"{MIMIR_URL}/prometheus",
         }
 
     # Assert
@@ -98,8 +92,8 @@ def test_provider_sender_sends_data_with_ingress_url_on_relation_joined(
     with context(context.on.relation_joined(prometheus_api), state=state) as manager:
         state_out = manager.run()
         expected = {
-            "direct_url": MIMIR_URL,
-            "ingress_url": MIMIR_INGRESS_URL,
+            "direct_url": f"{MIMIR_URL}/prometheus",
+            "ingress_url": f"{MIMIR_INGRESS_URL}/prometheus",
         }
 
     # Assert
@@ -130,7 +124,7 @@ def test_provider_sends_data_on_leader_elected(
     with context(context.on.leader_elected(), state=state) as manager:
         state_out = manager.run()
         expected = {
-            "direct_url": MIMIR_URL,
+            "direct_url": f"{MIMIR_URL}/prometheus",
         }
 
     # Assert

--- a/tests/scenario/test_prometheus_api_lib.py
+++ b/tests/scenario/test_prometheus_api_lib.py
@@ -16,16 +16,16 @@ INTERFACE_NAME = "app-data-interface"
 
 # Note: if this is changed, the PrometheusApiAppData concrete classes below need to change their constructors to match
 SAMPLE_APP_DATA = PrometheusApiAppData(
-    ingress_url="http://www.ingress-url.com/",
-    direct_url="http://www.internal-url.com/",
+    ingress_url="http://www.ingress-url.com/prometheus",
+    direct_url="http://www.internal-url.com/prometheus",
 )
 SAMPLE_APP_DATA_2 = PrometheusApiAppData(
-    ingress_url="http://www.ingress-url2.com/",
-    direct_url="http://www.internal-url2.com/",
+    ingress_url="http://www.ingress-url2.com/prometheus",
+    direct_url="http://www.internal-url2.com/prometheus",
 )
 SAMPLE_APP_DATA_NO_INGRESS_URL = PrometheusApiAppData(
-    ingress_url="http://www.ingress-url.com/",
-    direct_url="http://www.internal-url.com/",
+    ingress_url="http://www.ingress-url.com/prometheus",
+    direct_url="http://www.internal-url.com/prometheus",
 )
 
 


### PR DESCRIPTION
## Issue
#115 implemented the prometheus-api relation but exposed the wrong url for the prometheus api. Mimir's prometheus api is located at /prometheus, not the root path

## Solution
This commit updates the url sent on prometheus-api to fix this issue.

## Context
#115

## Testing Instructions
Covered by unit tests. Can also test this is the correct endpoint to do prometheus queries by querying prometheus at `COORDINATOR_IP/prometheus`

## Upgrade Notes
-