### PR TITLE
feat: enable custom resolvers in NGINX config

### DIFF
--- a/src/nginx_config.py
+++ b/src/nginx_config.py
@@ -11,6 +11,7 @@ from cosl.coordinated_workers.coordinator import Coordinator
 from cosl.coordinated_workers.nginx import CERT_PATH, KEY_PATH, is_ipv6_enabled
 
 logger = logging.getLogger(__name__)
+RESOLV_CONF_PATH = "/etc/resolv.conf"
 
 
 def _locations_distributor(tls: bool) -> List[Dict[str, Any]]:
@@ -416,7 +417,7 @@ class NginxConfig:
 
 def _get_dns_ip_address():
     """Obtain DNS ip address from /etc/resolv.conf."""
-    resolv = Path("/etc/resolv.conf").read_text()
+    resolv = Path(RESOLV_CONF_PATH).read_text()
     for line in resolv.splitlines():
         if line.startswith("nameserver"):
             # assume there's only one

--- a/src/nginx_config.py
+++ b/src/nginx_config.py
@@ -173,8 +173,7 @@ def _locations_compactor(tls: bool) -> List[Dict[str, Any]]:
 
 LOCATIONS_BASIC: List[Dict[str, Any]] = [
     {
-        # TODO PR had a $backend var in "args" and added another directive
-        # https://github.com/canonical/tempo-coordinator-k8s-operator/pull/88/files#diff-0116a9b741399a7bac8d1015f203baf6f53391c2ba9b7320fe04876e006c0f62R175
+        # FIXME update with tempo PR $backend
         "directive": "location",
         "args": ["=", "/"],
         "block": [
@@ -288,7 +287,6 @@ class NginxConfig:
                 {
                     "directive": "upstream",
                     "args": [role],
-                    # TODO see https://github.com/canonical/tempo-coordinator-k8s-operator/pull/88/files#diff-0116a9b741399a7bac8d1015f203baf6f53391c2ba9b7320fe04876e006c0f62L144
                     "block": [
                         # TODO: uncomment the below directive when nginx version >= 1.27.3
                         # monitor changes of IP addresses and automatically modify the upstream config without the need of restarting nginx.

--- a/tests/unit/test_nginx_config.py
+++ b/tests/unit/test_nginx_config.py
@@ -1,9 +1,13 @@
+import tempfile
 from contextlib import contextmanager
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from nginx_config import NginxConfig
+
+sample_dns_ip = "198.18.0.0"
 
 
 @contextmanager
@@ -28,6 +32,7 @@ def coordinator():
             "overrides-exporter": ["http://some.mimir.worker.0:8080"],
             "flusher": ["http://some.mimir.worker.0:8080"],
             "query-frontend": ["http://some.mimir.worker.0:8080"],
+            "query-scheduler": ["http://some.mimir.worker.0:8080"],
             "querier": ["http://some.mimir.worker.0:8080"],
             "store-gateway": ["http://some.mimir.worker.1:8080"],
             "ingester": ["http://some.mimir.worker.1:8080"],
@@ -42,6 +47,7 @@ def coordinator():
     coord.s3_ready = MagicMock(return_value=True)
     coord.nginx = MagicMock()
     coord.nginx.are_certificates_on_disk = MagicMock(return_value=True)
+    coord.hostname = "localhost"  # crossplane.build does not allow unittest.mock objects
     return coord
 
 
@@ -60,6 +66,14 @@ def topology():
     return top
 
 
+@contextmanager
+def mock_resolv_conf(contents: str):
+    with tempfile.NamedTemporaryFile() as tf:
+        Path(tf.name).write_text(contents)
+        with patch("nginx_config.RESOLV_CONF_PATH", tf.name):
+            yield
+
+
 @pytest.mark.parametrize(
     "addresses_by_role",
     [
@@ -69,7 +83,6 @@ def topology():
     ],
 )
 def test_upstreams_config(nginx_config, coordinator, addresses_by_role):
-    # TODO improve these tests
     nginx_port = 8080
     upstreams_config = nginx_config._upstreams(addresses_by_role, nginx_port)
     expected_config = [
@@ -102,3 +115,46 @@ def test_servers_config(ipv6, tls):
         assert ipv6_directive in server_config["block"]
     else:
         assert ipv6_directive not in server_config["block"]
+
+
+def _assert_config_per_role(source_dict, address, prepared_config, tls):
+    # as entire config is in a format that's hard to parse (and crossplane returns a string), we look for servers,
+    # upstreams and correct proxy/grpc_pass instructions.
+    # FIXME we get -> server "1.2.3.5:<MagicMock name=\'mock.nginx.options.__getitem__() ..." since we mock the coordinator
+    # FIXME How can we test this? And where do we get our ports from?
+    for port in source_dict.values():
+        assert f"server {address}:{port};" in prepared_config
+        assert f"listen {port}" in prepared_config
+        assert f"listen [::]:{port}" in prepared_config
+    for protocol in source_dict.keys():
+        sanitised_protocol = protocol.replace("_", "-")
+        assert f"upstream {sanitised_protocol}" in prepared_config
+
+        if "grpc" in protocol:
+            assert f"set $backend grpc{'s' if tls else ''}://{sanitised_protocol}"
+            assert "grpc_pass $backend" in prepared_config
+        else:
+            assert f"set $backend http{'s' if tls else ''}://{sanitised_protocol}"
+            assert "proxy_pass $backend" in prepared_config
+
+
+@pytest.mark.parametrize("tls", (True, False))
+def test_nginx_config_contains_upstreams_and_proxy_pass(
+    context, nginx_container, coordinator, addresses, tls
+):
+    coordinator.nginx.are_certificates_on_disk = tls
+    with mock_resolv_conf(f"nameserver {sample_dns_ip}"):
+        nginx = NginxConfig()
+
+    prepared_config = nginx.config(coordinator)
+    assert f"resolver {sample_dns_ip};" in prepared_config
+
+    for role, addresses in addresses.items():
+        for address in addresses:
+            if role == "distributor":
+                _assert_config_per_role({"ssl": 443}, address, prepared_config, tls)
+            if role == "query-frontend":
+                _assert_config_per_role({"ssl": 443}, address, prepared_config, tls)
+
+
+"worker_processes 5;\nerror_log /dev/stderr error;\npid /tmp/nginx.pid;\nworker_rlimit_nofile 8192;\nevents {\n    worker_connections 4096;\n}\nhttp {\n    upstream distributor {\n        server \"1.2.3.5:<MagicMock name='mock.nginx.options.__getitem__()' id='127454170141008'>\";\n    }\n    upstream ingester {\n        server \"1.2.3.6:<MagicMock name='mock.nginx.options.__getitem__()' id='127454170141008'>\";\n    }\n    upstream querier {\n        server \"1.2.4.7:<MagicMock name='mock.nginx.options.__getitem__()' id='127454170141008'>\";\n    }\n    upstream query-frontend {\n        server \"1.2.5.1:<MagicMock name='mock.nginx.options.__getitem__()' id='127454170141008'>\";\n    }\n    upstream compactor {\n        server \"1.2.6.6:<MagicMock name='mock.nginx.options.__getitem__()' id='127454170141008'>\";\n    }\n    upstream overrides-exporter {\n        server \"1.2.8.4:<MagicMock name='mock.nginx.options.__getitem__()' id='127454170141008'>\";\n    }\n    upstream query-scheduler {\n        server \"1.2.8.5:<MagicMock name='mock.nginx.options.__getitem__()' id='127454170141008'>\";\n    }\n    upstream flusher {\n        server \"1.2.8.6:<MagicMock name='mock.nginx.options.__getitem__()' id='127454170141008'>\";\n    }\n    upstream store-gateway {\n        server \"1.2.8.7:<MagicMock name='mock.nginx.options.__getitem__()' id='127454170141008'>\";\n    }\n    upstream ruler {\n        server \"1.2.8.8:<MagicMock name='mock.nginx.options.__getitem__()' id='127454170141008'>\";\n    }\n    upstream alertmanager {\n        server \"1.2.8.9:<MagicMock name='mock.nginx.options.__getitem__()' id='127454170141008'>\";\n    }\n    client_body_temp_path /tmp/client_temp;\n    proxy_temp_path /tmp/proxy_temp_path;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n    uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;\n    default_type application/octet-stream;\n    log_format main '$remote_addr - $remote_user [$time_local]  $status \"$request\" $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\"';\n    map $status $loggable {\n        ~^[23] 0;\n        default 1;\n    }\n    access_log /dev/stderr;\n    sendfile on;\n    tcp_nopush on;\n    resolver 198.18.0.0;\n    map $http_x_scope_orgid $ensured_x_scope_orgid {\n        default $http_x_scope_orgid;\n        '' anonymous;\n    }\n    proxy_read_timeout 300;\n    server {\n        listen 443 ssl;\n        listen [::]:443 ssl;\n        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;\n        server_name localhost;\n        ssl_certificate /etc/nginx/certs/server.cert;\n        ssl_certificate_key /etc/nginx/certs/server.key;\n        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;\n        ssl_ciphers HIGH:!aNULL:!MD5;\n        location = / {\n            return 200 \"'OK'\";\n            auth_basic off;\n        }\n        location = /status {\n            stub_status;\n        }\n        location /distributor {\n            proxy_pass https://distributor;\n        }\n        location /api/v1/push {\n            proxy_pass https://distributor;\n        }\n        location /otlp/v1/metrics {\n            proxy_pass https://distributor;\n        }\n        location /alertmanager {\n            proxy_pass https://alertmanager;\n        }\n        location /multitenant_alertmanager/status {\n            proxy_pass https://alertmanager;\n        }\n        location /api/v1/alerts {\n            proxy_pass https://alertmanager;\n        }\n        location /prometheus/config/v1/rules {\n            proxy_pass https://ruler;\n        }\n        location /prometheus/api/v1/rules {\n            proxy_pass https://ruler;\n        }\n        location /prometheus/api/v1/alerts {\n            proxy_pass https://ruler;\n        }\n        location = /ruler/ring {\n            proxy_pass https://ruler;\n        }\n        location /prometheus {\n            proxy_pass https://query-frontend;\n        }\n        location = /api/v1/status/buildinfo {\n            proxy_pass https://query-frontend;\n        }\n        location = /api/v1/upload/block/ {\n            proxy_pass https://compactor;\n        }\n    }\n}"

--- a/tests/unit/test_nginx_config.py
+++ b/tests/unit/test_nginx_config.py
@@ -69,6 +69,7 @@ def topology():
     ],
 )
 def test_upstreams_config(nginx_config, coordinator, addresses_by_role):
+    # TODO improve these tests
     nginx_port = 8080
     upstreams_config = nginx_config._upstreams(addresses_by_role, nginx_port)
     expected_config = [


### PR DESCRIPTION
> [!NOTE]
> This PR will be closed in favour of:
> - https://github.com/canonical/cos-lib/pull/143
> - https://github.com/canonical/mimir-coordinator-k8s-operator/pull/130

## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #128 


## Solution
<!-- A summary of the solution addressing the above issue -->
Use Tempo as an example for the custom resolvers since the feature was enabled in:
- https://github.com/canonical/tempo-coordinator-k8s-operator/pull/88


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
The resolvers differ between microk8s and canonical-k8s:
microk8s -> `kube-dns.kube-system.svc.cluster.local.`
canonical-k8s -> `coredns`


## Recommendations
- Accoding to [this post](https://stackoverflow.com/a/40331256/3516684), Nginx has implemented its own internal non-blocking resolver. We also need the features: config file contains variables in domain names, track IP changes, and Nginx reload.
From [nginx docs](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#upstream)
1. Use `Syntax:	resolver address ... [valid=time]` to shorten the `valid` attribute on the resolver to something like `5s` as by default it'll use the default DNS TTL which might be large. In the backend for reverse proxy you usually want to be reactive to change
2. Shorten the deafult DNS timeout (`30s`, huge when requests are pending to be proxied) with a `resolver_timeout` to something like `5s`.


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. `tox -e unit -- tests/unit/test_nginx_config.py`
- [ ] @vishvikkrishnan to deploy on canonical-k8s and see if the custom resolver overwrites the nginx config to `coredns`
