### PR TITLE
fix: disable the default max alerts per tenant to work with cos

### DIFF
--- a/src/mimir_config.py
+++ b/src/mimir_config.py
@@ -315,6 +315,6 @@ class MimirConfig:
     # Maximum number of rule groups per-tenant. 0 to disable. (default 70)
     def _build_limits_config(self) -> Dict[str, Any]:
         return {
-            "ruler_max_rules_per_rule_group": 100,
-            "ruler_max_rule_groups_per_tenant": 200,
+            "ruler_max_rules_per_rule_group": 0,
+            "ruler_max_rule_groups_per_tenant": 0,
         }

--- a/src/mimir_config.py
+++ b/src/mimir_config.py
@@ -137,6 +137,7 @@ class MimirConfig:
             "store_gateway": self._build_store_gateway_config(coordinator.cluster),
             "blocks_storage": self._build_blocks_storage_config(),
             "memberlist": self._build_memberlist_config(coordinator.topology, coordinator.cluster),
+            "limits": self._build_limits_config(),
         }
 
         if coordinator.s3_ready:
@@ -307,3 +308,8 @@ class MimirConfig:
             "cluster_label": f"{top['model']}_{top['model_uuid']}_{top['application']}",
             "join_members": list(cluster.gather_addresses()),
         }
+
+    # ruler_max_rule_groups_per_tenant: int
+    # Maximum number of rule groups per-tenant. 0 to disable.
+    def _build_limits_config(self) -> Dict[str, Any]:
+        return {"ruler_max_rule_groups_per_tenant": 200}

--- a/src/mimir_config.py
+++ b/src/mimir_config.py
@@ -309,7 +309,12 @@ class MimirConfig:
             "join_members": list(cluster.gather_addresses()),
         }
 
+    # ruler_max_rules_per_rule_group
+    # Maximum number of rules per rule group per-tenant. 0 to disable. (default 20)
     # ruler_max_rule_groups_per_tenant: int
-    # Maximum number of rule groups per-tenant. 0 to disable.
+    # Maximum number of rule groups per-tenant. 0 to disable. (default 70)
     def _build_limits_config(self) -> Dict[str, Any]:
-        return {"ruler_max_rule_groups_per_tenant": 200}
+        return {
+            "ruler_max_rules_per_rule_group": 100,
+            "ruler_max_rule_groups_per_tenant": 200,
+        }


### PR DESCRIPTION
## Issue
Closes #148.


## Solution
Disable the per-tenant alert limit.



## Context
This was discovered and addressed in the context of Partner Cloud testing.


## Testing Instructions
Applying the COS terraform module and then refreshing the charm to include these local changes. I manually ran this test in the Partner Cloud deployment.
