### PR TITLE
feat: utests for ingress TLS

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -44,6 +44,8 @@ logger = logging.getLogger(__name__)
 
 RULES_DIR = "/etc/mimir-alerts/rules"
 ALERTS_HASH_PATH = "/etc/mimir-alerts/alerts.sha256"
+NGINX_PORT = NginxHelper._port
+NGINX_TLS_PORT = NginxHelper._tls_port
 
 
 @trace_charm(
@@ -178,10 +180,10 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
     def internal_url(self) -> str:
         """Returns workload's FQDN. Used for ingress."""
         scheme = "http"
-        port = 8080
+        port = NGINX_PORT
         if hasattr(self, "coordinator") and self.coordinator.nginx.are_certificates_on_disk:
             scheme = "https"
-            port = 443
+            port = NGINX_TLS_PORT
         return f"{scheme}://{self.hostname}:{port}"
 
     @property

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,6 +17,11 @@ logger = logging.getLogger(__name__)
 store = defaultdict(str)
 
 
+@pytest.fixture(scope="session")
+def cos_channel():
+    return "2/edge"
+
+
 def timed_memoizer(func):
     @functools.wraps(func)
     async def wrapper(*args, **kwargs):

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -11,8 +11,6 @@ from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
-COS_CHANNEL = "2/edge"
-
 
 def charm_resources(metadata_file="charmcraft.yaml") -> Dict[str, str]:
     with open(metadata_file, "r") as file:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -11,6 +11,8 @@ from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
+COS_CHANNEL = "2/edge"
+
 
 def charm_resources(metadata_file="charmcraft.yaml") -> Dict[str, str]:
     with open(metadata_file, "r") as file:

--- a/tests/integration/test_charm_ha.py
+++ b/tests/integration/test_charm_ha.py
@@ -9,7 +9,6 @@ import logging
 import pytest
 import requests
 from helpers import (
-    COS_CHANNEL,
     charm_resources,
     configure_minio,
     configure_s3_integrator,
@@ -28,15 +27,15 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.setup
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest, mimir_charm: str):
+async def test_build_and_deploy(ops_test: OpsTest, mimir_charm: str, cos_channel):
     """Build the charm-under-test and deploy it together with related charms."""
     assert ops_test.model is not None  # for pyright
     await asyncio.gather(
         ops_test.model.deploy(mimir_charm, "mimir", resources=charm_resources(), trust=True),
-        ops_test.model.deploy("prometheus-k8s", "prometheus", channel=COS_CHANNEL, trust=True),
-        ops_test.model.deploy("loki-k8s", "loki", channel=COS_CHANNEL, trust=True),
-        ops_test.model.deploy("grafana-k8s", "grafana", channel=COS_CHANNEL, trust=True),
-        ops_test.model.deploy("grafana-agent-k8s", "agent", channel=COS_CHANNEL),
+        ops_test.model.deploy("prometheus-k8s", "prometheus", channel=cos_channel, trust=True),
+        ops_test.model.deploy("loki-k8s", "loki", channel=cos_channel, trust=True),
+        ops_test.model.deploy("grafana-k8s", "grafana", channel=cos_channel, trust=True),
+        ops_test.model.deploy("grafana-agent-k8s", "agent", channel=cos_channel),
         ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge", trust=True),
         # Deploy and configure Minio and S3
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
@@ -60,27 +59,27 @@ async def test_build_and_deploy(ops_test: OpsTest, mimir_charm: str):
 
 @pytest.mark.setup
 @pytest.mark.abort_on_fail
-async def test_deploy_workers(ops_test: OpsTest):
+async def test_deploy_workers(ops_test: OpsTest, cos_channel):
     """Deploy the Mimir workers."""
     assert ops_test.model is not None
     await ops_test.model.deploy(
         "mimir-worker-k8s",
         "worker-read",
-        channel=COS_CHANNEL,
+        channel=cos_channel,
         config={"role-read": True},
         trust=True,
     )
     await ops_test.model.deploy(
         "mimir-worker-k8s",
         "worker-write",
-        channel=COS_CHANNEL,
+        channel=cos_channel,
         config={"role-write": True},
         trust=True,
     )
     await ops_test.model.deploy(
         "mimir-worker-k8s",
         "worker-backend",
-        channel=COS_CHANNEL,
+        channel=cos_channel,
         config={"role-backend": True},
         trust=True,
     )

--- a/tests/integration/test_charm_ha.py
+++ b/tests/integration/test_charm_ha.py
@@ -9,6 +9,7 @@ import logging
 import pytest
 import requests
 from helpers import (
+    COS_CHANNEL,
     charm_resources,
     configure_minio,
     configure_s3_integrator,
@@ -32,10 +33,10 @@ async def test_build_and_deploy(ops_test: OpsTest, mimir_charm: str):
     assert ops_test.model is not None  # for pyright
     await asyncio.gather(
         ops_test.model.deploy(mimir_charm, "mimir", resources=charm_resources(), trust=True),
-        ops_test.model.deploy("prometheus-k8s", "prometheus", channel="2/edge", trust=True),
-        ops_test.model.deploy("loki-k8s", "loki", channel="2/edge", trust=True),
-        ops_test.model.deploy("grafana-k8s", "grafana", channel="2/edge", trust=True),
-        ops_test.model.deploy("grafana-agent-k8s", "agent", channel="2/edge"),
+        ops_test.model.deploy("prometheus-k8s", "prometheus", channel=COS_CHANNEL, trust=True),
+        ops_test.model.deploy("loki-k8s", "loki", channel=COS_CHANNEL, trust=True),
+        ops_test.model.deploy("grafana-k8s", "grafana", channel=COS_CHANNEL, trust=True),
+        ops_test.model.deploy("grafana-agent-k8s", "agent", channel=COS_CHANNEL),
         ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge", trust=True),
         # Deploy and configure Minio and S3
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
@@ -65,21 +66,21 @@ async def test_deploy_workers(ops_test: OpsTest):
     await ops_test.model.deploy(
         "mimir-worker-k8s",
         "worker-read",
-        channel="2/edge",
+        channel=COS_CHANNEL,
         config={"role-read": True},
         trust=True,
     )
     await ops_test.model.deploy(
         "mimir-worker-k8s",
         "worker-write",
-        channel="2/edge",
+        channel=COS_CHANNEL,
         config={"role-write": True},
         trust=True,
     )
     await ops_test.model.deploy(
         "mimir-worker-k8s",
         "worker-backend",
-        channel="2/edge",
+        channel=COS_CHANNEL,
         config={"role-backend": True},
         trust=True,
     )

--- a/tests/integration/test_charm_ha_scaled.py
+++ b/tests/integration/test_charm_ha_scaled.py
@@ -10,6 +10,7 @@ import logging
 import pytest
 import requests
 from helpers import (
+    COS_CHANNEL,
     charm_resources,
     configure_minio,
     configure_s3_integrator,
@@ -31,10 +32,10 @@ async def test_build_and_deploy(ops_test: OpsTest, mimir_charm: str):
     assert ops_test.model is not None  # for pyright
     await asyncio.gather(
         ops_test.model.deploy(mimir_charm, "mimir", resources=charm_resources(), trust=True),
-        ops_test.model.deploy("prometheus-k8s", "prometheus", channel="2/edge", trust=True),
-        ops_test.model.deploy("loki-k8s", "loki", channel="2/edge", trust=True),
-        ops_test.model.deploy("grafana-k8s", "grafana", channel="2/edge", trust=True),
-        ops_test.model.deploy("grafana-agent-k8s", "agent", channel="2/edge"),
+        ops_test.model.deploy("prometheus-k8s", "prometheus", channel=COS_CHANNEL, trust=True),
+        ops_test.model.deploy("loki-k8s", "loki", channel=COS_CHANNEL, trust=True),
+        ops_test.model.deploy("grafana-k8s", "grafana", channel=COS_CHANNEL, trust=True),
+        ops_test.model.deploy("grafana-agent-k8s", "agent", channel=COS_CHANNEL),
         ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge", trust=True),
         # Deploy and configure Minio and S3
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
@@ -64,7 +65,7 @@ async def test_deploy_workers(ops_test: OpsTest):
     await ops_test.model.deploy(
         "mimir-worker-k8s",
         "worker-read",
-        channel="2/edge",
+        channel=COS_CHANNEL,
         config={"role-read": True},
         num_units=3,
         trust=True,
@@ -72,7 +73,7 @@ async def test_deploy_workers(ops_test: OpsTest):
     await ops_test.model.deploy(
         "mimir-worker-k8s",
         "worker-write",
-        channel="2/edge",
+        channel=COS_CHANNEL,
         config={"role-write": True},
         num_units=3,
         trust=True,
@@ -80,7 +81,7 @@ async def test_deploy_workers(ops_test: OpsTest):
     await ops_test.model.deploy(
         "mimir-worker-k8s",
         "worker-backend",
-        channel="2/edge",
+        channel=COS_CHANNEL,
         config={"role-backend": True},
         num_units=3,
         trust=True,

--- a/tests/integration/test_charm_monolithic.py
+++ b/tests/integration/test_charm_monolithic.py
@@ -10,6 +10,7 @@ import logging
 import pytest
 import requests
 from helpers import (
+    COS_CHANNEL,
     charm_resources,
     configure_minio,
     configure_s3_integrator,
@@ -31,10 +32,10 @@ async def test_build_and_deploy(ops_test: OpsTest, mimir_charm: str):
     assert ops_test.model is not None  # for pyright
     await asyncio.gather(
         ops_test.model.deploy(mimir_charm, "mimir", resources=charm_resources(), trust=True),
-        ops_test.model.deploy("prometheus-k8s", "prometheus", channel="2/edge", trust=True),
-        ops_test.model.deploy("loki-k8s", "loki", channel="2/edge", trust=True),
-        ops_test.model.deploy("grafana-k8s", "grafana", channel="2/edge", trust=True),
-        ops_test.model.deploy("grafana-agent-k8s", "agent", channel="2/edge"),
+        ops_test.model.deploy("prometheus-k8s", "prometheus", channel=COS_CHANNEL, trust=True),
+        ops_test.model.deploy("loki-k8s", "loki", channel=COS_CHANNEL, trust=True),
+        ops_test.model.deploy("grafana-k8s", "grafana", channel=COS_CHANNEL, trust=True),
+        ops_test.model.deploy("grafana-agent-k8s", "agent", channel=COS_CHANNEL),
         ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge", trust=True),
         # Deploy and configure Minio and S3
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
@@ -64,7 +65,7 @@ async def test_deploy_workers(ops_test: OpsTest):
     await ops_test.model.deploy(
         "mimir-worker-k8s",
         "worker",
-        channel="2/edge",
+        channel=COS_CHANNEL,
         config={"role-all": True, "role-query-frontend": True},
         trust=True,
     )

--- a/tests/integration/test_charm_monolithic.py
+++ b/tests/integration/test_charm_monolithic.py
@@ -10,7 +10,6 @@ import logging
 import pytest
 import requests
 from helpers import (
-    COS_CHANNEL,
     charm_resources,
     configure_minio,
     configure_s3_integrator,
@@ -27,15 +26,15 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.setup
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest, mimir_charm: str):
+async def test_build_and_deploy(ops_test: OpsTest, mimir_charm: str, cos_channel):
     """Build the charm-under-test and deploy it together with related charms."""
     assert ops_test.model is not None  # for pyright
     await asyncio.gather(
         ops_test.model.deploy(mimir_charm, "mimir", resources=charm_resources(), trust=True),
-        ops_test.model.deploy("prometheus-k8s", "prometheus", channel=COS_CHANNEL, trust=True),
-        ops_test.model.deploy("loki-k8s", "loki", channel=COS_CHANNEL, trust=True),
-        ops_test.model.deploy("grafana-k8s", "grafana", channel=COS_CHANNEL, trust=True),
-        ops_test.model.deploy("grafana-agent-k8s", "agent", channel=COS_CHANNEL),
+        ops_test.model.deploy("prometheus-k8s", "prometheus", channel=cos_channel, trust=True),
+        ops_test.model.deploy("loki-k8s", "loki", channel=cos_channel, trust=True),
+        ops_test.model.deploy("grafana-k8s", "grafana", channel=cos_channel, trust=True),
+        ops_test.model.deploy("grafana-agent-k8s", "agent", channel=cos_channel),
         ops_test.model.deploy("traefik-k8s", "traefik", channel="latest/edge", trust=True),
         # Deploy and configure Minio and S3
         # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
@@ -59,13 +58,13 @@ async def test_build_and_deploy(ops_test: OpsTest, mimir_charm: str):
 
 @pytest.mark.setup
 @pytest.mark.abort_on_fail
-async def test_deploy_workers(ops_test: OpsTest):
+async def test_deploy_workers(ops_test: OpsTest, cos_channel):
     """Deploy the Mimir workers."""
     assert ops_test.model is not None
     await ops_test.model.deploy(
         "mimir-worker-k8s",
         "worker",
-        channel=COS_CHANNEL,
+        channel=cos_channel,
         config={"role-all": True, "role-query-frontend": True},
         trust=True,
     )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -43,30 +43,14 @@ def context(mimir_charm):
 
 @pytest.fixture(scope="function")
 def nginx_container():
+    address_arg = f"--address=http://{socket.getfqdn()}:{NGINX_PORT}"
+    address_arg_tls = f"--address=https://{socket.getfqdn()}:{NGINX_TLS_PORT}"
     return Container(
         "nginx",
         can_connect=True,
         execs={
-            Exec(
-                [
-                    "mimirtool",
-                    "rules",
-                    "sync",
-                    f"--address=http://{socket.getfqdn()}:{NGINX_PORT}",
-                    "--id=anonymous",
-                ],
-                return_code=0,
-            ),
-            Exec(
-                [
-                    "mimirtool",
-                    "rules",
-                    "sync",
-                    f"--address=https://{socket.getfqdn()}:{NGINX_TLS_PORT}",
-                    "--id=anonymous",
-                ],
-                return_code=0,
-            ),
+            Exec(["mimirtool", "rules", "sync", address_arg, "--id=anonymous"], return_code=0),
+            Exec(["mimirtool", "rules", "sync", address_arg_tls, "--id=anonymous"], return_code=0),
         },
     )
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,7 +10,7 @@ from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
 from ops import ActiveStatus
 from scenario import Container, Context, Exec, Relation
 
-from charm import MimirCoordinatorK8SOperatorCharm
+from charm import NGINX_PORT, NGINX_TLS_PORT, MimirCoordinatorK8SOperatorCharm
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -52,11 +52,21 @@ def nginx_container():
                     "mimirtool",
                     "rules",
                     "sync",
-                    f"--address=http://{socket.getfqdn()}:8080",
+                    f"--address=http://{socket.getfqdn()}:{NGINX_PORT}",
                     "--id=anonymous",
                 ],
                 return_code=0,
-            )
+            ),
+            Exec(
+                [
+                    "mimirtool",
+                    "rules",
+                    "sync",
+                    f"--address=https://{socket.getfqdn()}:{NGINX_TLS_PORT}",
+                    "--id=anonymous",
+                ],
+                return_code=0,
+            ),
         },
     )
 

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,3 +1,5 @@
 def get_relation_data(relations, endpoint, key):
     """Retrieve the value for a given key from the local_app_data of a relation with the specified endpoint."""
-    return next((r.local_app_data[key] for r in relations if r.endpoint == endpoint), None)
+    relevant = [r.local_app_data[key] for r in relations if r.endpoint == endpoint]
+    assert len(relevant) < 2, "This helper currently assumes only one relation."
+    return relevant[0] if relevant else None

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,0 +1,3 @@
+def get_relation_data(relations, endpoint, key):
+    """Retrieve the value for a given key from the local_app_data of a relation with the specified endpoint."""
+    return next((r.local_app_data[key] for r in relations if r.endpoint == endpoint), None)

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -1,0 +1,55 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from unittest.mock import patch
+
+import scenario
+from coordinated_workers.nginx import Nginx
+from helpers import get_relation_data
+from scenario import Relation, State
+
+from charm import NGINX_PORT, NGINX_TLS_PORT
+
+
+def test_ingress_tls(
+    context,
+    s3,
+    all_worker,
+    nginx_container,
+    nginx_prometheus_exporter_container,
+):
+    # GIVEN Loki is related over the ingress and certificates endpoints
+    ingress = Relation("ingress")
+    certificates = Relation("certificates")
+
+    state_in = State(
+        relations=[
+            s3,
+            all_worker,
+            ingress,
+            certificates,
+        ],
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+        unit_status=scenario.ActiveStatus(),
+        leader=True,
+    )
+
+    # WHEN TLS is not yet available
+    with context(context.on.relation_joined(ingress), state_in) as mgr:
+        charm = mgr.charm
+        state_out = mgr.run()
+
+        # THEN there are no certificates on disk
+        assert not charm.coordinator.nginx.are_certificates_on_disk
+
+        # AND Loki publishes its Nginx non-TLS port in the ingress databag
+        assert get_relation_data(state_out.relations, "ingress", "port") == str(NGINX_PORT)
+
+    # AND WHEN TLS is enabled
+    with patch.object(Nginx, "are_certificates_on_disk", return_value=True):
+        # AND the ingress databag is updated
+        state_out = context.run(context.on.relation_changed(ingress), state_in)
+
+        # THEN Loki publishes its Nginx TLS port in the ingress databag
+        assert get_relation_data(state_out.relations, "ingress", "scheme") == '"https"'
+        assert get_relation_data(state_out.relations, "ingress", "port") == str(NGINX_TLS_PORT)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Similar to:
- https://github.com/canonical/loki-coordinator-k8s-operator/pull/69

## Solution
<!-- A summary of the solution addressing the above issue -->
Add unit tests for validating databag contents over `ingress` relation contains correct information when TLS is enabled.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
This PR includes some itest updates to bump our charms to deploy from `2/edge`

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
`tox -e unit`

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
