### PR TITLE
Lift limits

### DIFF
--- a/src/mimir_config.py
+++ b/src/mimir_config.py
@@ -316,14 +316,34 @@ class MimirConfig:
             "join_members": list(cluster.gather_addresses()),
         }
 
-    # ruler_max_rules_per_rule_group
-    # Maximum number of rules per rule group per-tenant. 0 to disable. (default 20)
-    # ruler_max_rule_groups_per_tenant: int
-    # Maximum number of rule groups per-tenant. 0 to disable. (default 70)
     def _build_limits_config(self) -> Dict[str, Any]:
+        """Default and per-tenant limits imposed by components.
+
+        Our deployment does not support multi-tenancy, so per-user limits are effectively global limits.
+
+        Ref: https://grafana.com/docs/mimir/latest/configure/configuration-parameters/#limits
+        """
         limits_config: Dict[str, Any] = {
-            "ruler_max_rules_per_rule_group": 0,
-            "ruler_max_rule_groups_per_tenant": 0,
+            # Maximum number of rules per rule group per-tenant. 0 to disable.
+            # CLI flag: -ruler.max-rules-per-rule-group
+            "ruler_max_rules_per_rule_group": 0,  # default = 20
+
+            # Maximum number of rule groups per-tenant. 0 to disable.
+            # CLI flag: -ruler.max-rule-groups-per-tenant
+            "ruler_max_rule_groups_per_tenant": 0,  # default = 70
+
+            # The maximum number of in-memory series per tenant, across the cluster before
+            # replication. 0 to disable.
+            # CLI flag: -ingester.max-global-series-per-user
+            "max_global_series_per_user": 0,  # default = 150000
+
+            # Per-tenant ingestion rate limit in samples per second.
+            # CLI flag: -distributor.ingestion-rate-limit
+            "ingestion_rate": 100_000,  # default = 10000
+
+            # Per-tenant allowed ingestion burst size (in number of samples).
+            # CLI flag: -distributor.ingestion-burst-size
+            "ingestion_burst_size": 2_000_000,  # default = 200000]
         }
 
         # Set the max global exemplars per user based on the value of _max_global_exemplars_per_user
@@ -332,5 +352,3 @@ class MimirConfig:
         limits_config["max_global_exemplars_per_user"] = val
 
         return limits_config
-
-


### PR DESCRIPTION
## Issue
In large production deployments, specifically with snmp-exporter, `pebble logs mimir` shows:

```
2025-09-04T13:53:19.286Z [mimir] ts=2025-09-04T13:53:19.286288943Z caller=push.go:184 level=error user=anonymous 
msg="detected an error while ingesting Prometheus remote-write request (the request may have been partially ingested)" 
httpCode=429 err="the request has been rejected because the tenant exceeded the ingestion rate limit, 
set to 10000 items/s with a maximum allowed burst of 200000. This limit is applied on the total number of samples, 
exemplars and metadata received across all distributors (err-mimir-tenant-max-ingestion-rate). To adjust the related per-
tenant limits, configure -distributor.ingestion-rate-limit and -distributor.ingestion-burst-size, 
or contact your service administrator." insight=true
```

```shell
2025-09-04T14:00:53.586Z [mimir] ts=2025-09-04T14:00:53.556789283Z caller=push.go:184 level=error user=anonymous 
msg="detected an error while ingesting Prometheus remote-write request (the request may have been partially ingested)" 
httpCode=400 err="send data to ingesters: failed pushing to ingester mimir-write-1: user=anonymous: per-user series 
limit of 150000 exceeded (err-mimir-max-series-per-user). To adjust the related per-tenant limit, configure -ingester.max-
global-series-per-user, or contact your service administrator. (sampled 1/10)" insight=true
```

Currently we only have single-tenant (in the grafana sense) deployments, so the per-user limits are effectively global limits.


## Solution
This PR disables the per-user series limit and loosens the other limits.


## Context
When the need arises in the future, we could expose some of the limits as config options.
We will have additional insight after load-testing.