### PR TITLE
chore: add API endpoint info for Catalogue item

### DIFF
--- a/lib/charms/traefik_k8s/v2/ingress.py
+++ b/lib/charms/traefik_k8s/v2/ingress.py
@@ -84,7 +84,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 16
+LIBPATCH = 17
 
 PYDEPS = ["pydantic"]
 
@@ -456,11 +456,16 @@ class IngressPerAppDataRemovedEvent(RelationEvent):
     """Event representing that ingress data has been removed for an app."""
 
 
+class IngressPerAppEndpointsUpdatedEvent(RelationEvent):
+    """Event representing that the proxied endpoints have been updated."""
+
+
 class IngressPerAppProviderEvents(ObjectEvents):
     """Container for IPA Provider events."""
 
     data_provided = EventSource(IngressPerAppDataProvidedEvent)
     data_removed = EventSource(IngressPerAppDataRemovedEvent)
+    endpoints_updated = EventSource(IngressPerAppEndpointsUpdatedEvent)
 
 
 @dataclass
@@ -508,7 +513,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
             )
 
     def _handle_relation_broken(self, event):
-        self.on.data_removed.emit(event.relation)  # type: ignore
+        self.on.data_removed.emit(event.relation, event.relation.app)  # type: ignore
 
     def wipe_ingress_data(self, relation: Relation):
         """Clear ingress data from relation."""
@@ -523,6 +528,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
             )
             return
         del relation.data[self.app]["ingress"]
+        self.on.endpoints_updated.emit(relation=relation, app=relation.app)
 
     def _get_requirer_units_data(self, relation: Relation) -> List["IngressRequirerUnitData"]:
         """Fetch and validate the requirer's unit databag."""
@@ -556,7 +562,9 @@ class IngressPerAppProvider(_IngressPerAppBase):
                 self._get_requirer_app_data(relation), self._get_requirer_units_data(relation)
             )
         except (pydantic.ValidationError, DataValidationError) as e:
-            raise DataValidationError("failed to validate ingress requirer data") from e
+            raise DataValidationError(
+                "failed to validate ingress requirer data: %s" % str(e)
+            ) from e
 
     def is_ready(self, relation: Optional[Relation] = None):
         """The Provider is ready if the requirer has sent valid data."""
@@ -566,7 +574,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
         try:
             self.get_data(relation)
         except (DataValidationError, NotReadyError) as e:
-            log.debug("Provider not ready; validation error encountered: %s" % str(e))
+            log.info("Provider not ready; validation error encountered: %s" % str(e))
             return False
         return True
 
@@ -591,6 +599,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
         ingress_url = {"url": url}
         try:
             IngressProviderAppData(ingress=ingress_url).dump(relation.data[self.app])  # type: ignore
+            self.on.endpoints_updated.emit(relation=relation, app=relation.app)
         except pydantic.ValidationError as e:
             # If we cannot validate the url as valid, publish an empty databag and log the error.
             log.error(f"Failed to validate ingress url '{url}' - got ValidationError {e}")
@@ -756,7 +765,7 @@ class IngressPerAppRequirer(_IngressPerAppBase):
 
     def _handle_relation_broken(self, event):
         self._stored.current_url = None  # type: ignore
-        self.on.revoked.emit(event.relation)  # type: ignore
+        self.on.revoked.emit(relation=event.relation, app=event.relation.app)  # type: ignore
 
     def _handle_upgrade_or_leader(self, event):
         """On upgrade/leadership change: ensure we publish the data we have."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -206,7 +206,7 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
     def _catalogue_item(self) -> CatalogueItem:
         api_endpoints = {
             "Prometheus rules": "/prometheus/api/v1/rules",
-            "Prometheus Alerts": "/promtheus/api/v1/alerts",
+            "Active alerts": "/promtheus/api/v1/alerts",
             "Query": "/prometheus/api/v1/query",
             "Push": "/api/v1/push",
             "OTLP metrics": "/otlp/v1/metrics",

--- a/src/charm.py
+++ b/src/charm.py
@@ -204,6 +204,11 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
 
     @property
     def _catalogue_item(self) -> CatalogueItem:
+        api_endpoints = {
+            "Prometheus rules": "/prometheus/api/v1/rules",
+            "Prometheus Alerts": "/promtheus/api/v1/alerts",
+            "Query": "/prometheus/api/v1/query"
+        }
         """A catalogue application entry for this Mimir instance."""
         return CatalogueItem(
             name="Mimir",
@@ -214,6 +219,8 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
                 "multi-tenant, long-term storage for Prometheus. "
                 "(no user interface available)"
             ),
+            api_docs="https://grafana.com/docs/mimir/latest/references/http-api/",
+            api_endpoints={key: f"{self.external_url}{path}" for key, path in api_endpoints.items()},
         )
 
     # TODO: make this a static method in the Nginx class

--- a/src/charm.py
+++ b/src/charm.py
@@ -207,7 +207,9 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
         api_endpoints = {
             "Prometheus rules": "/prometheus/api/v1/rules",
             "Prometheus Alerts": "/promtheus/api/v1/alerts",
-            "Query": "/prometheus/api/v1/query"
+            "Query": "/prometheus/api/v1/query",
+            "Push": "/api/v1/push",
+            "OTLP metrics": "/otlp/v1/metrics",
         }
         """A catalogue application entry for this Mimir instance."""
         return CatalogueItem(


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
A [recent PR in Catalogue](https://github.com/canonical/catalogue-k8s-operator/pull/184) added functionality to the Catalogue library for Catalogue Items to provide links to their API docs and API endpoints. We need to add these fields when Mimir creates its Catalogue Items.

In tandem with PRs in:
- [Prometheus](https://github.com/canonical/prometheus-k8s-operator/pull/726)
- [Loki](https://github.com/canonical/loki-coordinator-k8s-operator/pull/88)

## Solution
<!-- A summary of the solution addressing the above issue -->
This PR links to the upstream [HTTP API docs for Mimir by Grafana](https://grafana.com/docs/mimir/latest/references/http-api/). It also lists some of the more commonly accessed ones to the list of API endpoints. 
The added endpoints are:
```python
api_endpoints = {
            "Prometheus rules": "/prometheus/api/v1/rules",
            "Prometheus Alerts": "/promtheus/api/v1/alerts",
            "Query": "/prometheus/api/v1/query",
            "Push": "/api/v1/push",
            "OTLP metrics": "/otlp/v1/metrics",
        }
```
The end result for the API endpoints looks like below:
<img width="2530" height="1312" alt="image" src="https://github.com/user-attachments/assets/b17c6ad0-c956-44e5-8263-d714c4d8bada" />
Note: the PR also performs `charmcraft fetch-lib` to get the latest Catalogue library and in the process, updates some other libs.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
