### PR TITLE
ops pre-release test: use ops==3.4.0b3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ version = "0.0"
 requires-python = "~=3.10"   # https://packages.ubuntu.com/jammy/python3
 
 dependencies = [
+  "ops==3.4.0b3",
   "coordinated-workers",
   "charmed-service-mesh-helpers>=0.2.0",
   "lightkube-extensions",
@@ -30,7 +31,7 @@ dev = [
   "opentelemetry-sdk",
   "opentelemetry-exporter-otlp-proto-http",
   # scenario
-  "ops[testing]>=2.17",
+  "ops[testing]==3.4.0b3",
   # interface
   "pytest-interface-tester>2.0.0",
 ]


### PR DESCRIPTION
This PR is not for merging, it's just for running CI with the upcoming ops v3.4.0.